### PR TITLE
Refactored visibility.

### DIFF
--- a/Python/kraken/core/builder.py
+++ b/Python/kraken/core/builder.py
@@ -466,12 +466,9 @@ class Builder(object):
 
         for i in xrange(kObject.getNumAttributeGroups()):
             attributeGroup = kObject.getAttributeGroupByIndex(i)
-
-            attributeCount = attributeGroup.getNumAttributes()
             self.buildAttributeGroup(attributeGroup)
 
         return True
-
 
 
     def buildHierarchy(self, kObject, component=None):
@@ -649,7 +646,6 @@ class Builder(object):
         # Build input connections
         for i in xrange(kObject.getNumAttributeGroups()):
             attributeGroup = kObject.getAttributeGroupByIndex(i)
-
             for y in xrange(attributeGroup.getNumAttributes()):
                 attribute = attributeGroup.getAttributeByIndex(y)
                 self.connectAttribute(attribute)

--- a/Python/kraken/core/objects/object_3d.py
+++ b/Python/kraken/core/objects/object_3d.py
@@ -12,6 +12,7 @@ from kraken.core.objects.scene_item import SceneItem
 from kraken.core.maths.xfo import Xfo
 from kraken.core.maths.rotation_order import RotationOrder
 from kraken.core.objects.attributes.attribute_group import AttributeGroup
+from kraken.core.objects.attributes.bool_attribute import BoolAttribute
 
 
 class Object3D(SceneItem):
@@ -27,8 +28,10 @@ class Object3D(SceneItem):
         self._xfo = Xfo()
         self._ro = RotationOrder()
         self._color = None
-        self._visibility = True
-        self._shapeVisibility = True
+
+        self._implicitAttrGrp = AttributeGroup("implicitAttrGrp", self)
+        self._visibility = BoolAttribute('visibility', True, self._implicitAttrGrp)
+        self._shapeVisibility = BoolAttribute('shapeVisibility', True, self._implicitAttrGrp)
 
         if parent is not None:
             parent.addChild(self)
@@ -123,7 +126,6 @@ class Object3D(SceneItem):
     # =============
     # Name Methods
     # =============
-
     def getBuildName(self):
         """Returns the build name for the object.
 
@@ -263,7 +265,6 @@ class Object3D(SceneItem):
 
         return parent
 
-
     def getLayer(self):
         """Returns the Layer the object belongs to.
 
@@ -291,7 +292,6 @@ class Object3D(SceneItem):
         """
 
         return self._component
-
 
     def setComponent(self, component):
         """Sets the component attribute of this object.
@@ -861,6 +861,16 @@ class Object3D(SceneItem):
     # ===================
     # Visibility Methods
     # ===================
+    def getVisibilityAttr(self):
+        """Returns the Visibility attribute object.
+
+        Returns:
+            BoolAttribute: Attribute that holds the value of the visibility.
+
+        """
+
+        return self._visibility
+
     def getVisibility(self):
         """Returns the visibility status of the scene item.
 
@@ -869,8 +879,7 @@ class Object3D(SceneItem):
 
         """
 
-        return self._visibility
-
+        return self._visibility.getValue()
 
     def setVisibility(self, value):
         """Sets the visibility of the scene object.
@@ -883,10 +892,20 @@ class Object3D(SceneItem):
 
         """
 
-        self._visibility = value
+        self._visibility.setValue(value)
 
         return True
 
+
+    def getShapeVisibilityAttr(self):
+        """Returns the Shape Visibility attribute object.
+
+        Returns:
+            BoolAttribute: Attribute that holds the value of the shape visibility.
+
+        """
+
+        return self._shapeVisibility
 
     def getShapeVisibility(self):
         """Returns the shape visibility status of the scene item.
@@ -896,8 +915,7 @@ class Object3D(SceneItem):
 
         """
 
-        return self._shapeVisibility
-
+        return self._shapeVisibility.getValue()
 
     def setShapeVisibility(self, value):
         """Sets the shape visibility of the scene object.
@@ -910,7 +928,7 @@ class Object3D(SceneItem):
 
         """
 
-        self._shapeVisibility = value
+        self._shapeVisibility.setValue(value)
 
         return True
 


### PR DESCRIPTION
ShapeVis and Vis are now true BoolAttribute objects.
Can be queried and connected to other visibility attrs and other BoolAttrs too.