### PR TITLE
Remove DCC code from Core kraken system module

### DIFF
--- a/Python/kraken/core/kraken_system.py
+++ b/Python/kraken/core/kraken_system.py
@@ -18,7 +18,7 @@ import FabricEngine.Core
 
 import kraken
 from kraken.core.profiler import Profiler
-from kraken.plugins.fabric_client import getFabricClient
+from kraken.plugins import getFabricClient
 
 
 krakenSystemModuleDir = os.path.join(os.path.dirname(os.path.realpath(__file__)))
@@ -64,31 +64,11 @@ class KrakenSystem(object):
         if self.client == None:
             Profiler.getInstance().push("loadCoreClient")
 
-            try:
-                imp.find_module('cmds')
-                host = 'Maya'
-            except ImportError:
-                try:
-                    imp.find_module('sipyutils')
-                    host = 'Softimage'
-                except ImportError:
-                    host = 'Python'
+            client = getFabricClient()
+            if client is None:
+                client = FabricEngine.Core.createClient({'guarded': True})
 
-            if host == "Python":
-                # self.client = FabricEngine.Core.createClient({'optimizeSynchronously': True, 'guarded': True})
-                self.client = FabricEngine.Core.createClient({'guarded': True})
-
-            elif host == "Maya":
-                contextID = cmds.fabricSplice('getClientContextID')
-                if contextID == '':
-                    cmds.fabricSplice('constructClient')
-                    contextID = cmds.fabricSplice('getClientContextID')
-
-                # Pull out the Splice client.
-                self.client = FabricEngine.Core.createClient({"contextID": contextID})
-
-            elif host == "Softimage":
-
+            self.client = client
 
             self.loadExtension('Math')
 

--- a/Python/kraken/core/kraken_system.py
+++ b/Python/kraken/core/kraken_system.py
@@ -18,9 +18,11 @@ import FabricEngine.Core
 
 import kraken
 from kraken.core.profiler import Profiler
+from kraken.plugins.fabric_client import getFabricClient
+
 
 krakenSystemModuleDir = os.path.join(os.path.dirname(os.path.realpath(__file__)))
-krakenDir=os.path.abspath(os.path.join(krakenSystemModuleDir, '..', '..', '..'))
+krakenDir = os.path.abspath(os.path.join(krakenSystemModuleDir, '..', '..', '..'))
 os.environ['KRAKEN_PATH']  = krakenDir
 
 krakenExtsDir = os.path.join(krakenDir, 'Exts')
@@ -33,6 +35,7 @@ if 'FABRIC_DFG_PATH' in os.environ:
         os.environ['FABRIC_DFG_PATH'] = canvasPresetsDir + os.pathsep + os.environ['FABRIC_DFG_PATH']
 else:
     os.environ['FABRIC_DFG_PATH'] = canvasPresetsDir
+
 
 class KrakenSystem(object):
     """The KrakenSystem is a singleton object used to provide an interface with
@@ -85,15 +88,7 @@ class KrakenSystem(object):
                 self.client = FabricEngine.Core.createClient({"contextID": contextID})
 
             elif host == "Softimage":
-                from win32com.client.dynamic import Dispatch
-                si = Dispatch("XSI.Application").Application
-                contextID = si.fabricSplice('getClientContextID')
-                if contextID == '':
-                    si.fabricSplice('constructClient')
-                    contextID = si.fabricSplice('getClientContextID')
 
-                # Pull out the Splice client.
-                self.client = FabricEngine.Core.createClient({"contextID": contextID})
 
             self.loadExtension('Math')
 

--- a/Python/kraken/plugins/__init__.py
+++ b/Python/kraken/plugins/__init__.py
@@ -67,7 +67,7 @@ def getSynchronizer():
 
 
 def getLogger():
-    """Returns the appropriate log fn module for the DCC.
+    """Returns the appropriate logging module for the DCC.
 
     Return:
     Function, function pointer for the DCC
@@ -94,3 +94,32 @@ def getLogger():
         logger = OutputLog()
 
     return logger
+
+
+def getFabricClient():
+    """Returns the appropriate Fabric client for the DCC.
+
+    Args:
+        Arguments (Type): information.
+
+    Returns:
+        Type: True if successful.
+
+    """
+
+    client = None
+
+    for eachPlugin in __all__:
+        mod = __import__("kraken.plugins." + eachPlugin, fromlist=['dccTest'])
+        reload(mod)
+
+        if mod.dccTest() is True:
+            loaded_mod = __import__("kraken.plugins." + eachPlugin + ".fabric_client", fromlist=['getClient'])
+            reload(loaded_mod)
+
+            client = loaded_mod.getClient()
+
+    if client is None:
+        print "Failed to find DCC client. Falling back to Python client."
+
+    return client

--- a/Python/kraken/plugins/canvas_plugin/fabric_client.py
+++ b/Python/kraken/plugins/canvas_plugin/fabric_client.py
@@ -1,0 +1,6 @@
+import FabricEngine.Core
+
+
+def getClient():
+
+    return FabricEngine.Core.createClient({'guarded': True})

--- a/Python/kraken/plugins/maya_plugin/fabric_client.py
+++ b/Python/kraken/plugins/maya_plugin/fabric_client.py
@@ -1,12 +1,12 @@
 import FabricEngine.Core
 
+from kraken.plugins.maya_plugin.utils import *
+
 
 def getClient():
-    si = Dispatch("XSI.Application").Application
-    contextID = si.fabricSplice('getClientContextID')
+    contextID = cmds.fabricSplice('getClientContextID')
     if contextID == '':
-        si.fabricSplice('constructClient')
-        contextID = si.fabricSplice('getClientContextID')
+        cmds.fabricSplice('constructClient')
+        contextID = cmds.fabricSplice('getClientContextID')
 
-    # Pull out the Splice client.
     return FabricEngine.Core.createClient({"contextID": contextID})

--- a/Python/kraken/plugins/maya_plugin/fabric_client.py
+++ b/Python/kraken/plugins/maya_plugin/fabric_client.py
@@ -1,0 +1,12 @@
+import FabricEngine.Core
+
+
+def getClient():
+    si = Dispatch("XSI.Application").Application
+    contextID = si.fabricSplice('getClientContextID')
+    if contextID == '':
+        si.fabricSplice('constructClient')
+        contextID = si.fabricSplice('getClientContextID')
+
+    # Pull out the Splice client.
+    return FabricEngine.Core.createClient({"contextID": contextID})

--- a/Python/kraken/plugins/si_plugin/fabric_client.py
+++ b/Python/kraken/plugins/si_plugin/fabric_client.py
@@ -1,0 +1,14 @@
+import FabricEngine.Core
+
+from win32com.client.dynamic import Dispatch
+
+
+def getClient():
+    si = Dispatch("XSI.Application").Application
+    contextID = si.fabricSplice('getClientContextID')
+    if contextID == '':
+        si.fabricSplice('constructClient')
+        contextID = si.fabricSplice('getClientContextID')
+
+    # Pull out the Splice client.
+    return FabricEngine.Core.createClient({"contextID": contextID})

--- a/Python/kraken/plugins/si_plugin/fabric_client.py
+++ b/Python/kraken/plugins/si_plugin/fabric_client.py
@@ -1,14 +1,12 @@
 import FabricEngine.Core
 
-from win32com.client.dynamic import Dispatch
+from kraken.plugins.si_plugin.utils import *
 
 
 def getClient():
-    si = Dispatch("XSI.Application").Application
     contextID = si.fabricSplice('getClientContextID')
     if contextID == '':
         si.fabricSplice('constructClient')
         contextID = si.fabricSplice('getClientContextID')
 
-    # Pull out the Splice client.
     return FabricEngine.Core.createClient({"contextID": contextID})


### PR DESCRIPTION
This change makes it so when any new DCC plugin for Kraken is added the kraken_system module won't need to add DCC related code for it to work. It abstracts this work into the plugins __init__.py and dynamically loads the correct client from there.

This fixes #335 