### PR TITLE
Need to remember that not all "connections" are connections.  

### DIFF
--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -873,15 +873,16 @@ class Builder(Builder):
                     opObject = connectedObjects
                     dccSceneItem = self.getDCCSceneItem(opObject)
 
-                    # Handle output connections to visibility attributes.
-                    if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
-                        dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
-                        dccSceneItem = dccItem.attr('visibility')
+                    if dccSceneItem is not None: # may be a value, not a sceneItem
+                        # Handle output connections to visibility attributes.
+                        if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
+                            dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
+                            dccSceneItem = dccItem.attr('visibility')
 
-                    elif opObject.getName() == 'shapeVisibility' and opObject.getParent().getName() == 'implicitAttrGrp':
-                        dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
-                        shape = dccItem.getShape()
-                        dccSceneItem = shape.attr('visibility')
+                        elif opObject.getName() == 'shapeVisibility' and opObject.getParent().getName() == 'implicitAttrGrp':
+                            dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
+                            shape = dccItem.getShape()
+                            dccSceneItem = shape.attr('visibility')
 
                     connectionTargets = { 'opObject': opObject, 'dccSceneItem': dccSceneItem }
 


### PR DESCRIPTION
We can set attributes directly, so opObject might be the number 6 and thus no attribute getName().  getDCCSceneItem will return None if the opObject is anything but a sceneItem.  So, test that first.  Not sure how to update this for Softimage or even if the bug is there.