### PR TITLE
Fix for build failure wrt setting visibility

### DIFF
--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -866,7 +866,17 @@ class Builder(Builder):
                     connectionTargets = []
                     for i in xrange(len(connectedObjects)):
                         opObject = connectedObjects[i]
+
                         dccSceneItem = self.getDCCSceneItem(opObject)
+                        if hasattr(opObject, "getName"):
+                            # Handle output connections to visibility attributes.
+                            if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
+                                dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
+                                dccSceneItem = dccItem.attr('visibility')
+                            elif opObject.getName() == 'shapeVisibility' and opObject.getParent().getName() == 'implicitAttrGrp':
+                                dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
+                                shape = dccItem.getShape()
+                                dccSceneItem = shape.attr('visibility')
 
                         connectionTargets.append({'opObject': opObject, 'dccSceneItem': dccSceneItem})
                 else:
@@ -877,14 +887,11 @@ class Builder(Builder):
 
                     opObject = connectedObjects
                     dccSceneItem = self.getDCCSceneItem(opObject)
-
-                    if not isinstance(opObject, (str, unicode, int, float, long, bool)):
-
+                    if hasattr(opObject, "getName"):
                         # Handle output connections to visibility attributes.
                         if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
                             dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
                             dccSceneItem = dccItem.attr('visibility')
-
                         elif opObject.getName() == 'shapeVisibility' and opObject.getParent().getName() == 'implicitAttrGrp':
                             dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
                             shape = dccItem.getShape()


### PR DESCRIPTION
Even checking for explicit types causes an error for our builds.  In this case, we are setting a Vec3 directly, so opObject is a tuple.  This is not the most elegant solution, but at least it has a higher chance of success for now.