### PR TITLE
Feature/394 canvas op refactor

### DIFF
--- a/Python/kraken/core/objects/operators/canvas_operator.py
+++ b/Python/kraken/core/objects/operators/canvas_operator.py
@@ -1,7 +1,7 @@
-"""Kraken - objects.operators.kl_operator module.
+"""Kraken - objects.operators.canvas_operator module.
 
 Classes:
-CanvasOperator - Splice operator object.
+CanvasOperator - Canvas operator object.
 
 """
 
@@ -15,7 +15,7 @@ from kraken.core.kraken_system import ks
 
 
 class CanvasOperator(Operator):
-    """Splice Operator representation."""
+    """Canvas Operator representation."""
 
     def __init__(self, name, canvasPresetPath):
         super(CanvasOperator, self).__init__(name)
@@ -31,12 +31,6 @@ class CanvasOperator(Operator):
             1: 'IO',
             2: 'Out'
         }
-
-        # ownerOutPortData = {
-        #     'name': None,
-        #     'typeSpec': None,
-        #     'execPortType': None
-        # }
 
         # Initialize the inputs and outputs based on the given args.
         for i in xrange(self.node.getExecPortCount()):

--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -776,245 +776,279 @@ class Builder(Builder):
 
         """
 
-        def validateArg(rtVal, argName, argDataType):
-            """Validate argument types when passing built in Python types.
+        self.buildCanvasOperator(kOperator, isKLBased=True)
 
-            Args:
-                rtVal (RTVal): rtValue object.
-                argName (str): Name of the argument being validated.
-                argDataType (str): Type of the argument being validated.
+        # def validateArg(rtVal, argName, argDataType):
+        #     """Validate argument types when passing built in Python types.
 
-            """
+        #     Args:
+        #         rtVal (RTVal): rtValue object.
+        #         argName (str): Name of the argument being validated.
+        #         argDataType (str): Type of the argument being validated.
 
-            # Validate types when passing a built in Python type
-            if type(rtVal) in (bool, str, int, float):
-                if argDataType in ('Scalar', 'Float32', 'UInt32', 'Integer'):
-                    if type(rtVal) not in (float, int):
-                        raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
+        #     """
 
-                elif argDataType == 'Boolean':
-                    if type(rtVal) != bool and not (type(rtVal) == int and (rtVal == 0 or rtVal == 1)):
-                        raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
+        #     # Validate types when passing a built in Python type
+        #     if type(rtVal) in (bool, str, int, float):
+        #         if argDataType in ('Scalar', 'Float32', 'UInt32', 'Integer'):
+        #             if type(rtVal) not in (float, int):
+        #                 raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
 
-                elif argDataType == 'String':
-                    if type(rtVal) != str:
-                        raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
+        #         elif argDataType == 'Boolean':
+        #             if type(rtVal) != bool and not (type(rtVal) == int and (rtVal == 0 or rtVal == 1)):
+        #                 raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
 
-        try:
-            solverTypeName = kOperator.getSolverTypeName()
+        #         elif argDataType == 'String':
+        #             if type(rtVal) != str:
+        #                 raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
 
-            # Create Splice Operator
-            spliceNode = pm.createNode('canvasNode', name=kOperator.getName())
-            self._registerSceneItemPair(kOperator, pm.PyNode(spliceNode))
-            pm.FabricCanvasSetExtDeps(mayaNode=spliceNode,
-                                      execPath="",
-                                      extDep=kOperator.getExtension())
+        # try:
+        #     solverTypeName = kOperator.getSolverTypeName()
 
-            pm.FabricCanvasAddFunc(mayaNode=spliceNode,
-                                   execPath="",
-                                   title=kOperator.getName(),
-                                   code="dfgEntry {}", xPos="100", yPos="100")
+        #     # Create Splice Operator
+        #     spliceNode = pm.createNode('canvasNode', name=kOperator.getName())
+        #     self._registerSceneItemPair(kOperator, pm.PyNode(spliceNode))
 
-            pm.FabricCanvasAddPort(mayaNode=spliceNode,
-                                   execPath=kOperator.getName(),
-                                   desiredPortName="solver",
-                                   portType="IO",
-                                   typeSpec=solverTypeName,
-                                   connectToPortPath="",
-                                   extDep=kOperator.getExtension())
+        #     pm.FabricCanvasSetExtDeps(mayaNode=spliceNode,
+        #                               execPath="",
+        #                               extDep=kOperator.getExtension())
 
-            pm.FabricCanvasAddPort(mayaNode=spliceNode,
-                                   execPath="",
-                                   desiredPortName="solver",
-                                   portType="IO",
-                                   typeSpec=solverTypeName,
-                                   connectToPortPath="",
-                                   extDep=kOperator.getExtension())
+        #     pm.FabricCanvasAddFunc(mayaNode=spliceNode,
+        #                            execPath="",
+        #                            title=kOperator.getName(),
+        #                            code="dfgEntry {}", xPos="100", yPos="100")
 
-            pm.FabricCanvasConnect(mayaNode=spliceNode,
-                                   execPath="",
-                                   srcPortPath="solver",
-                                   dstPortPath=kOperator.getName() + ".solver")
+        #     pm.FabricCanvasAddPort(mayaNode=spliceNode,
+        #                            execPath=kOperator.getName(),
+        #                            desiredPortName="solver",
+        #                            portType="IO",
+        #                            typeSpec=solverTypeName,
+        #                            connectToPortPath="",
+        #                            extDep=kOperator.getExtension())
 
-            pm.FabricCanvasConnect(mayaNode=spliceNode,
-                                   execPath="",
-                                   srcPortPath=kOperator.getName() + ".solver",
-                                   dstPortPath="solver")
+        #     pm.FabricCanvasAddPort(mayaNode=spliceNode,
+        #                            execPath="",
+        #                            desiredPortName="solver",
+        #                            portType="IO",
+        #                            typeSpec=solverTypeName,
+        #                            connectToPortPath="",
+        #                            extDep=kOperator.getExtension())
 
-            arraySizes = {}
-            # connect the operator to the objects in the DCC
-            args = kOperator.getSolverArgs()
-            for i in xrange(len(args)):
-                arg = args[i]
-                argName = arg.name.getSimpleType()
-                argDataType = arg.dataType.getSimpleType()
-                argConnectionType = arg.connectionType.getSimpleType()
+        #     pm.FabricCanvasConnect(mayaNode=spliceNode,
+        #                            execPath="",
+        #                            srcPortPath="solver",
+        #                            dstPortPath=kOperator.getName() + ".solver")
 
-                if argConnectionType == 'In':
-                    pm.FabricCanvasAddPort(mayaNode=spliceNode,
-                                           execPath="",
-                                           desiredPortName=argName,
-                                           portType="In",
-                                           typeSpec=argDataType,
-                                           connectToPortPath="")
+        #     pm.FabricCanvasConnect(mayaNode=spliceNode,
+        #                            execPath="",
+        #                            srcPortPath=kOperator.getName() + ".solver",
+        #                            dstPortPath="solver")
 
-                    pm.FabricCanvasAddPort(mayaNode=spliceNode,
-                                           execPath=kOperator.getName(),
-                                           desiredPortName=argName,
-                                           portType="In",
-                                           typeSpec=argDataType,
-                                           connectToPortPath="")
+        #     arraySizes = {}
+        #     # connect the operator to the objects in the DCC
+        #     args = kOperator.getSolverArgs()
+        #     for i in xrange(len(args)):
+        #         arg = args[i]
+        #         argName = arg.name.getSimpleType()
+        #         argDataType = arg.dataType.getSimpleType()
+        #         argConnectionType = arg.connectionType.getSimpleType()
 
-                    pm.FabricCanvasConnect(mayaNode=spliceNode,
-                                           execPath="",
-                                           srcPortPath=argName,
-                                           dstPortPath=kOperator.getName() + "." + argName)
+        #         if argConnectionType == 'In':
+        #             pm.FabricCanvasAddPort(mayaNode=spliceNode,
+        #                                    execPath="",
+        #                                    desiredPortName=argName,
+        #                                    portType="In",
+        #                                    typeSpec=argDataType,
+        #                                    connectToPortPath="")
 
-                elif argConnectionType in ['IO', 'Out']:
-                    pm.FabricCanvasAddPort(mayaNode=spliceNode, execPath="",
-                                           desiredPortName=argName,
-                                           portType="Out",
-                                           typeSpec=argDataType,
-                                           connectToPortPath="")
+        #             pm.FabricCanvasAddPort(mayaNode=spliceNode,
+        #                                    execPath=kOperator.getName(),
+        #                                    desiredPortName=argName,
+        #                                    portType="In",
+        #                                    typeSpec=argDataType,
+        #                                    connectToPortPath="")
 
-                    pm.FabricCanvasAddPort(mayaNode=spliceNode,
-                                           execPath=kOperator.getName(),
-                                           desiredPortName=argName,
-                                           portType="Out",
-                                           typeSpec=argDataType,
-                                           connectToPortPath="")
+        #             pm.FabricCanvasConnect(mayaNode=spliceNode,
+        #                                    execPath="",
+        #                                    srcPortPath=argName,
+        #                                    dstPortPath=kOperator.getName() + "." + argName)
 
-                    pm.FabricCanvasConnect(mayaNode=spliceNode,
-                                           execPath="",
-                                           srcPortPath=kOperator.getName() + "." + argName,
-                                           dstPortPath=argName)
+        #         elif argConnectionType in ['IO', 'Out']:
+        #             pm.FabricCanvasAddPort(
+        #                 mayaNode=spliceNode,
+        #                 execPath="",
+        #                 desiredPortName=argName,
+        #                 portType="Out",
+        #                 typeSpec=argDataType,
+        #                 connectToPortPath="")
 
-                if argDataType == 'EvalContext':
-                    continue
-                if argName == 'time':
-                    pm.expression(o=spliceNode + '.time', s=spliceNode + '.time = time;')
-                    continue
-                if argName == 'frame':
-                    pm.expression(o=spliceNode + '.frame', s=spliceNode + '.frame = frame;')
-                    continue
+        #             pm.FabricCanvasAddPort(
+        #                 mayaNode=spliceNode,
+        #                 execPath=kOperator.getName(),
+        #                 desiredPortName=argName,
+        #                 portType="Out",
+        #                 typeSpec=argDataType,
+        #                 connectToPortPath="")
 
-                # Get the argument's input from the DCC
-                if argConnectionType == 'In':
-                    connectedObjects = kOperator.getInput(argName)
-                elif argConnectionType in ['IO', 'Out']:
-                    connectedObjects = kOperator.getOutput(argName)
+        #             pm.FabricCanvasConnect(
+        #                 mayaNode=spliceNode,
+        #                 execPath="",
+        #                 srcPortPath=kOperator.getName() + "." + argName,
+        #                 dstPortPath=argName)
+        #         else:
+        #             raise Exception("Invalid connection type:" + portConnectionType)
 
-                if argDataType.endswith('[]'):
+        #         if argDataType == 'EvalContext':
+        #             continue
+        #         if argName == 'time':
+        #             pm.expression(o=spliceNode + '.time', s=spliceNode + '.time = time;')
+        #             continue
+        #         if argName == 'frame':
+        #             pm.expression(o=spliceNode + '.frame', s=spliceNode + '.frame = frame;')
+        #             continue
 
-                    # In SpliceMaya, output arrays are not resized by the
-                    # system prior to calling into Splice, so we explicily
-                    # resize the arrays in the generated operator stub code.
-                    if argConnectionType in ['IO', 'Out']:
-                        arraySizes[argName] = len(connectedObjects)
+        #         # Get the argument's input from the DCC
+        #         if argConnectionType == 'In':
+        #             connectedObjects = kOperator.getInput(argName)
+        #         elif argConnectionType in ['IO', 'Out']:
+        #             connectedObjects = kOperator.getOutput(argName)
 
-                    connectionTargets = []
-                    for i in xrange(len(connectedObjects)):
-                        opObject = connectedObjects[i]
-                        dccSceneItem = self.getDCCSceneItem(opObject)
+        #         if argDataType.endswith('[]'):
 
-                        connectionTargets.append(
-                            {
-                                'opObject': opObject,
-                                'dccSceneItem': dccSceneItem
-                            })
-                else:
-                    if connectedObjects is None:
-                        raise Exception("Operator '" + kOperator.getName() +
-                                        "' of type '" + solverTypeName +
-                                        "' arg '" + argName + "' not connected.")
+        #             # In SpliceMaya, output arrays are not resized by the
+        #             # system prior to calling into Splice, so we explicily
+        #             # resize the arrays in the generated operator stub code.
+        #             if argConnectionType in ['IO', 'Out']:
+        #                 arraySizes[argName] = len(connectedObjects)
 
-                    opObject = connectedObjects
-                    dccSceneItem = self.getDCCSceneItem(opObject)
+        #             connectionTargets = []
+        #             for i in xrange(len(connectedObjects)):
+        #                 opObject = connectedObjects[i]
+        #                 dccSceneItem = self.getDCCSceneItem(opObject)
 
-                    connectionTargets = {
-                        'opObject': opObject,
-                        'dccSceneItem': dccSceneItem
-                    }
+        #                 if hasattr(opObject, "getName"):
+        #                     # Handle output connections to visibility attributes.
+        #                     if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
+        #                         dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
+        #                         dccSceneItem = dccItem.attr('visibility')
+        #                     elif opObject.getName() == 'shapeVisibility' and opObject.getParent().getName() == 'implicitAttrGrp':
+        #                         dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
+        #                         shape = dccItem.getShape()
+        #                         dccSceneItem = shape.attr('visibility')
 
-                # Add the Port for each arg.
-                if argConnectionType == 'In':
+        #                 connectionTargets.append(
+        #                     {
+        #                         'opObject': opObject,
+        #                         'dccSceneItem': dccSceneItem
+        #                     })
+        #         else:
+        #             if connectedObjects is None:
+        #                 if connectedObjects is None:
+        #                     logger.warning("Operator '" + kOperator.getName() +
+        #                                    "' of type '" + solverTypeName +
+        #                                    "' arg '" + argName + "' not connected.")
+        #                 continue
 
-                    def connectInput(tgt, opObject, dccSceneItem):
+        #             opObject = connectedObjects
+        #             dccSceneItem = self.getDCCSceneItem(opObject)
+        #             if hasattr(opObject, "getName"):
+        #                 # Handle output connections to visibility attributes.
+        #                 if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
+        #                     dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
+        #                     dccSceneItem = dccItem.attr('visibility')
+        #                 elif opObject.getName() == 'shapeVisibility' and opObject.getParent().getName() == 'implicitAttrGrp':
+        #                     dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
+        #                     shape = dccItem.getShape()
+        #                     dccSceneItem = shape.attr('visibility')
 
-                        if isinstance(opObject, Attribute):
-                            pm.connectAttr(dccSceneItem, tgt)
-                        elif isinstance(opObject, Object3D):
-                            pm.connectAttr(dccSceneItem.attr('worldMatrix'), tgt)
-                        elif isinstance(opObject, Xfo):
-                            self.setMat44Attr(tgt.partition(".")[0], tgt.partition(".")[2], opObject.toMat44())
-                        elif isinstance(opObject, Mat44):
-                            self.setMat44Attr(tgt.partition(".")[0], tgt.partition(".")[2], opObject)
-                        elif isinstance(opObject, Vec2):
-                            pm.setAttr(tgt, opObject.x, opObject.y, type="double2")
-                        elif isinstance(opObject, Vec3):
-                            pm.setAttr(tgt, opObject.x, opObject.y, opObject.z, type="double3")
-                        else:
-                            validateArg(opObject, argName, argDataType)
+        #             connectionTargets = {
+        #                 'opObject': opObject,
+        #                 'dccSceneItem': dccSceneItem
+        #             }
 
-                            pm.setAttr(tgt, opObject)
+        #         # Add the Port for each arg.
+        #         if argConnectionType == 'In':
 
-                    if argDataType.endswith('[]'):
-                        for i in xrange(len(connectionTargets)):
-                            connectInput(spliceNode + "." + argName + '[' + str(i) + ']',
-                                         connectionTargets[i]['opObject'],
-                                         connectionTargets[i]['dccSceneItem'])
-                    else:
-                        connectInput(spliceNode + "." + argName,
-                                     connectionTargets['opObject'],
-                                     connectionTargets['dccSceneItem'])
+        #             def connectInput(tgt, opObject, dccSceneItem):
+        #                 if isinstance(opObject, Attribute):
+        #                     pm.connectAttr(dccSceneItem, tgt)
+        #                 elif isinstance(opObject, Object3D):
+        #                     pm.connectAttr(dccSceneItem.attr('worldMatrix'), tgt)
+        #                 elif isinstance(opObject, Xfo):
+        #                     self.setMat44Attr(tgt.partition(".")[0], tgt.partition(".")[2], opObject.toMat44())
+        #                 elif isinstance(opObject, Mat44):
+        #                     self.setMat44Attr(tgt.partition(".")[0], tgt.partition(".")[2], opObject)
+        #                 elif isinstance(opObject, Vec2):
+        #                     pm.setAttr(tgt, opObject.x, opObject.y, type="double2")
+        #                 elif isinstance(opObject, Vec3):
+        #                     pm.setAttr(tgt, opObject.x, opObject.y, opObject.z, type="double3")
+        #                 else:
+        #                     validateArg(opObject, argName, argDataType)
 
-                elif argConnectionType in ['IO', 'Out']:
+        #                     pm.setAttr(tgt, opObject)
 
-                    def connectOutput(src, opObject, dccSceneItem):
-                        if isinstance(opObject, Attribute):
-                            pm.connectAttr(src, dccSceneItem, force=True)
-                        elif isinstance(opObject, Object3D):
-                            decomposeNode = pm.createNode('decomposeMatrix')
-                            pm.connectAttr(src,
-                                           decomposeNode.attr("inputMatrix"),
-                                           force=True)
+        #             if argDataType.endswith('[]'):
+        #                 for i in xrange(len(connectionTargets)):
+        #                     connectInput(
+        #                         spliceNode + "." + argName + '[' + str(i) + ']',
+        #                         connectionTargets[i]['opObject'],
+        #                         connectionTargets[i]['dccSceneItem'])
+        #             else:
+        #                 connectInput(
+        #                     spliceNode + "." + argName,
+        #                     connectionTargets['opObject'],
+        #                     connectionTargets['dccSceneItem'])
 
-                            decomposeNode.attr("outputRotate").connect(dccSceneItem.attr("rotate"))
-                            decomposeNode.attr("outputScale").connect(dccSceneItem.attr("scale"))
-                            decomposeNode.attr("outputTranslate").connect(dccSceneItem.attr("translate"))
-                        elif isinstance(opObject, Xfo):
-                            raise NotImplementedError("Kraken KL Operator cannot set Xfo outputs types directly!")
-                        elif isinstance(opObject, Mat44):
-                            raise NotImplementedError("Kraken KL Operator cannot set Mat44 outputs types directly!")
-                        else:
-                            raise NotImplementedError("Kraken KL Operator cannot set outputs with Python built-in types directly!")
+        #         elif argConnectionType in ['IO', 'Out']:
 
-                    if argDataType.endswith('[]'):
-                        for i in xrange(len(connectionTargets)):
-                            connectOutput(str(spliceNode + "." + argName) + '[' + str(i) + ']',
-                                          connectionTargets[i]['opObject'],
-                                          connectionTargets[i]['dccSceneItem'])
-                    else:
-                        connectOutput(str(spliceNode + "." + argName),
-                                      connectionTargets['opObject'],
-                                      connectionTargets['dccSceneItem'])
+        #             def connectOutput(src, opObject, dccSceneItem):
+        #                 if isinstance(opObject, Attribute):
+        #                     pm.connectAttr(src, dccSceneItem, force=True)
+        #                 elif isinstance(opObject, Object3D):
+        #                     decomposeNode = pm.createNode('decomposeMatrix')
+        #                     pm.connectAttr(src,
+        #                                    decomposeNode.attr("inputMatrix"),
+        #                                    force=True)
 
-            opSourceCode = kOperator.generateSourceCode(arraySizes=arraySizes)
-            pm.FabricCanvasSetCode(mayaNode=spliceNode,
-                                   execPath=kOperator.getName(),
-                                   code=opSourceCode)
+        #                     decomposeNode.attr("outputRotate").connect(dccSceneItem.attr("rotate"))
+        #                     decomposeNode.attr("outputScale").connect(dccSceneItem.attr("scale"))
+        #                     decomposeNode.attr("outputTranslate").connect(dccSceneItem.attr("translate"))
+        #                 elif isinstance(opObject, Xfo):
+        #                     raise NotImplementedError("Kraken KL Operator cannot set Xfo outputs types directly!")
+        #                 elif isinstance(opObject, Mat44):
+        #                     raise NotImplementedError("Kraken KL Operator cannot set Mat44 outputs types directly!")
+        #                 else:
+        #                     raise NotImplementedError("Kraken KL Operator cannot set outputs with Python built-in types directly!")
 
-        finally:
-            pass
+        #             if argDataType.endswith('[]'):
+        #                 for i in xrange(len(connectionTargets)):
+        #                     connectOutput(
+        #                         str(spliceNode + "." + argName) + '[' + str(i) + ']',
+        #                         connectionTargets[i]['opObject'],
+        #                         connectionTargets[i]['dccSceneItem'])
+        #             else:
+        #                 connectOutput(
+        #                     str(spliceNode + "." + argName),
+        #                     connectionTargets['opObject'],
+        #                     connectionTargets['dccSceneItem'])
+
+        #     opSourceCode = kOperator.generateSourceCode(arraySizes=arraySizes)
+        #     pm.FabricCanvasSetCode(mayaNode=spliceNode,
+        #                            execPath=kOperator.getName(),
+        #                            code=opSourceCode)
+
+        # finally:
+        #     pass
 
         return True
 
-    def buildCanvasOperator(self, kOperator):
+    def buildCanvasOperator(self, kOperator, isKLBased=False):
         """Builds Canvas Operators on the components.
 
         Args:
-            kOperator (Object): Kraken operator that represents a Canvas
+            kOperator (object): Kraken operator that represents a Canvas
                 operator.
+            isKLBased (bool): Whether the solver is based on a KL object.
 
         Return:
             bool: True if successful.
@@ -1046,64 +1080,160 @@ class Builder(Builder):
                         raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + portName + " (" + portDataType + ")")
 
         try:
-            host = ks.getCoreClient().DFG.host
-            opBinding = host.createBindingToPreset(kOperator.getPresetPath())
-            node = opBinding.getExec()
+            if isKLBased is False:
+                host = ks.getCoreClient().DFG.host
+                opBinding = host.createBindingToPreset(kOperator.getPresetPath())
+                node = opBinding.getExec()
 
-            portTypeMap = {
-                0: 'In',
-                1: 'IO',
-                2: 'Out'
-            }
+                portTypeMap = {
+                    0: 'In',
+                    1: 'IO',
+                    2: 'Out'
+                }
 
             # Create Canvas Operator
             canvasNode = pm.createNode('canvasNode', name=kOperator.getName())
             self._registerSceneItemPair(kOperator, pm.PyNode(canvasNode))
 
-            pm.FabricCanvasSetExtDeps(mayaNode=canvasNode, execPath="", extDep="Kraken")
-            graphNodeName = pm.FabricCanvasInstPreset(
-                mayaNode=canvasNode,
-                execPath="",
-                presetPath=kOperator.getPresetPath(),
-                xPos="100",
-                yPos="100")
+            pm.FabricCanvasSetExtDeps(mayaNode=canvasNode,
+                                      execPath="",
+                                      extDep=kOperator.getExtension())
+
+            if isKLBased is True:
+                solverTypeName = kOperator.getSolverTypeName()
+
+                pm.FabricCanvasAddFunc(mayaNode=canvasNode,
+                                   execPath="",
+                                   title=kOperator.getName(),
+                                   code="dfgEntry {}", xPos="100", yPos="100")
+
+                pm.FabricCanvasAddPort(mayaNode=canvasNode,
+                                       execPath=kOperator.getName(),
+                                       desiredPortName="solver",
+                                       portType="IO",
+                                       typeSpec=solverTypeName,
+                                       connectToPortPath="",
+                                       extDep=kOperator.getExtension())
+
+                pm.FabricCanvasAddPort(mayaNode=canvasNode,
+                                       execPath="",
+                                       desiredPortName="solver",
+                                       portType="IO",
+                                       typeSpec=solverTypeName,
+                                       connectToPortPath="",
+                                       extDep=kOperator.getExtension())
+
+                pm.FabricCanvasConnect(mayaNode=canvasNode,
+                                       execPath="",
+                                       srcPortPath="solver",
+                                       dstPortPath=kOperator.getName() + ".solver")
+
+                pm.FabricCanvasConnect(mayaNode=canvasNode,
+                                       execPath="",
+                                       srcPortPath=kOperator.getName() + ".solver",
+                                       dstPortPath="solver")
+            else:
+                graphNodeName = pm.FabricCanvasInstPreset(
+                    mayaNode=canvasNode,
+                    execPath="",
+                    presetPath=kOperator.getPresetPath(),
+                    xPos="100",
+                    yPos="100")
+
+            portCount = 0
+            if isKLBased is True:
+                portCount = len(kOperator.getSolverArgs())
+            else:
+                portCount = node.getExecPortCount()
 
             arraySizes = {}
-            for i in xrange(node.getExecPortCount()):
-                portName = node.getExecPortName(i)
-                portConnectionType = portTypeMap[node.getExecPortType(i)]
-                rtVal = opBinding.getArgValue(portName)
-                portDataType = rtVal.getTypeName().getSimpleType()
+            for i in xrange(portCount):
+
+                if isKLBased is True:
+                    args = kOperator.getSolverArgs()
+                    arg = args[i]
+                    portName = arg.name.getSimpleType()
+                    portConnectionType = arg.connectionType.getSimpleType()
+                    portDataType = arg.dataType.getSimpleType()
+                else:
+                    portName = node.getExecPortName(i)
+                    portConnectionType = portTypeMap[node.getExecPortType(i)]
+                    rtVal = opBinding.getArgValue(portName)
+                    portDataType = rtVal.getTypeName().getSimpleType()
 
                 if portConnectionType == 'In':
-                    pm.FabricCanvasAddPort(
-                        mayaNode=canvasNode,
-                        execPath="",
-                        desiredPortName=portName,
-                        portType="In",
-                        typeSpec=portDataType,
-                        connectToPortPath="")
+                    if isKLBased is True:
+                        pm.FabricCanvasAddPort(mayaNode=canvasNode,
+                                           execPath="",
+                                           desiredPortName=portName,
+                                           portType="In",
+                                           typeSpec=portDataType,
+                                           connectToPortPath="")
 
-                    pm.FabricCanvasConnect(
-                        mayaNode=canvasNode,
-                        execPath="",
-                        srcPortPath=portName,
-                        dstPortPath=graphNodeName + "." + portName)
+                        pm.FabricCanvasAddPort(mayaNode=canvasNode,
+                                               execPath=kOperator.getName(),
+                                               desiredPortName=portName,
+                                               portType="In",
+                                               typeSpec=portDataType,
+                                               connectToPortPath="")
+
+                        pm.FabricCanvasConnect(mayaNode=canvasNode,
+                                               execPath="",
+                                               srcPortPath=portName,
+                                               dstPortPath=kOperator.getName() + "." + argName)
+
+                    else:
+                        pm.FabricCanvasAddPort(
+                            mayaNode=canvasNode,
+                            execPath="",
+                            desiredPortName=portName,
+                            portType="In",
+                            typeSpec=portDataType,
+                            connectToPortPath="")
+
+                        pm.FabricCanvasConnect(
+                            mayaNode=canvasNode,
+                            execPath="",
+                            srcPortPath=portName,
+                            dstPortPath=graphNodeName + "." + portName)
 
                 elif portConnectionType in ['IO', 'Out']:
-                    pm.FabricCanvasAddPort(
-                        mayaNode=canvasNode,
-                        execPath="",
-                        desiredPortName=portName,
-                        portType="Out",
-                        typeSpec=portDataType,
-                        connectToPortPath="")
+                    if isKLBased is True:
+                        pm.FabricCanvasAddPort(
+                            mayaNode=canvasNode,
+                            execPath="",
+                            desiredPortName=portName,
+                            portType="Out",
+                            typeSpec=argDataType,
+                            connectToPortPath="")
 
-                    pm.FabricCanvasConnect(
-                        mayaNode=canvasNode,
-                        execPath="",
-                        srcPortPath=graphNodeName + "." + portName,
-                        dstPortPath=portName)
+                        pm.FabricCanvasAddPort(
+                            mayaNode=canvasNode,
+                            execPath=kOperator.getName(),
+                            desiredPortName=portName,
+                            portType="Out",
+                            typeSpec=argDataType,
+                            connectToPortPath="")
+
+                        pm.FabricCanvasConnect(
+                            mayaNode=canvasNode,
+                            execPath="",
+                            srcPortPath=kOperator.getName() + "." + portName,
+                            dstPortPath=portName)
+                    else:
+                        pm.FabricCanvasAddPort(
+                            mayaNode=canvasNode,
+                            execPath="",
+                            desiredPortName=portName,
+                            portType="Out",
+                            typeSpec=portDataType,
+                            connectToPortPath="")
+
+                        pm.FabricCanvasConnect(
+                            mayaNode=canvasNode,
+                            execPath="",
+                            srcPortPath=graphNodeName + "." + portName,
+                            dstPortPath=portName)
                 else:
                     raise Exception("Invalid connection type:" + portConnectionType)
 
@@ -1138,8 +1268,8 @@ class Builder(Builder):
                     connectionTargets = []
                     for i in xrange(len(connectedObjects)):
                         opObject = connectedObjects[i]
-
                         dccSceneItem = self.getDCCSceneItem(opObject)
+
                         if hasattr(opObject, "getName"):
                             # Handle output connections to visibility attributes.
                             if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
@@ -1156,9 +1286,10 @@ class Builder(Builder):
                                 'dccSceneItem': dccSceneItem
                             })
                 else:
-                    # If there are no connected objects, continue
                     if connectedObjects is None:
-                        pm.warning("Operator '" + kOperator.getName() + "' of type '" + kOperator.getPresetPath() + "' port '" + portName + "' not connected.")
+                        logger.warning("Operator '" + kOperator.getName() +
+                                       "' of type '" + kOperator.getPresetPath() +
+                                       "' port '" + portName + "' not connected.")
                         continue
 
                     opObject = connectedObjects
@@ -1216,15 +1347,15 @@ class Builder(Builder):
                     def connectOutput(src, opObject, dccSceneItem):
                         if isinstance(opObject, Attribute):
                             pm.connectAttr(src, dccSceneItem)
-
                         elif isinstance(opObject, Object3D):
                             decomposeNode = pm.createNode('decomposeMatrix')
-                            pm.connectAttr(src, decomposeNode.attr("inputMatrix"))
+                            pm.connectAttr(src,
+                                           decomposeNode.attr("inputMatrix"),
+                                           force=True)
 
                             decomposeNode.attr("outputRotate").connect(dccSceneItem.attr("rotate"))
                             decomposeNode.attr("outputScale").connect(dccSceneItem.attr("scale"))
                             decomposeNode.attr("outputTranslate").connect(dccSceneItem.attr("translate"))
-
                         elif isinstance(opObject, Xfo):
                             raise NotImplementedError("Kraken Canvas Operator cannot set object [%s] outputs with Xfo outputs types directly!")
                         elif isinstance(opObject, Mat44):
@@ -1243,6 +1374,12 @@ class Builder(Builder):
                             str(canvasNode + "." + portName),
                             connectionTargets['opObject'],
                             connectionTargets['dccSceneItem'])
+
+            if isKLBased is True:
+                opSourceCode = kOperator.generateSourceCode(arraySizes=arraySizes)
+                pm.FabricCanvasSetCode(mayaNode=spliceNode,
+                                       execPath=kOperator.getName(),
+                                       code=opSourceCode)
 
         finally:
             pass

--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -776,269 +776,10 @@ class Builder(Builder):
 
         """
 
+        # Code to build KL and Canvas based Operators has been merged.
+        # It's important to note here that the 'isKLBased' argument is set
+        # to true.
         self.buildCanvasOperator(kOperator, isKLBased=True)
-
-        # def validateArg(rtVal, argName, argDataType):
-        #     """Validate argument types when passing built in Python types.
-
-        #     Args:
-        #         rtVal (RTVal): rtValue object.
-        #         argName (str): Name of the argument being validated.
-        #         argDataType (str): Type of the argument being validated.
-
-        #     """
-
-        #     # Validate types when passing a built in Python type
-        #     if type(rtVal) in (bool, str, int, float):
-        #         if argDataType in ('Scalar', 'Float32', 'UInt32', 'Integer'):
-        #             if type(rtVal) not in (float, int):
-        #                 raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
-
-        #         elif argDataType == 'Boolean':
-        #             if type(rtVal) != bool and not (type(rtVal) == int and (rtVal == 0 or rtVal == 1)):
-        #                 raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
-
-        #         elif argDataType == 'String':
-        #             if type(rtVal) != str:
-        #                 raise TypeError(kOperator.getName() + ".evaluate(): Invalid Argument Value: " + str(rtVal) + " (" + type(rtVal).__name__ + "), for Argument: " + argName + " (" + argDataType + ")")
-
-        # try:
-        #     solverTypeName = kOperator.getSolverTypeName()
-
-        #     # Create Splice Operator
-        #     spliceNode = pm.createNode('canvasNode', name=kOperator.getName())
-        #     self._registerSceneItemPair(kOperator, pm.PyNode(spliceNode))
-
-        #     pm.FabricCanvasSetExtDeps(mayaNode=spliceNode,
-        #                               execPath="",
-        #                               extDep=kOperator.getExtension())
-
-        #     pm.FabricCanvasAddFunc(mayaNode=spliceNode,
-        #                            execPath="",
-        #                            title=kOperator.getName(),
-        #                            code="dfgEntry {}", xPos="100", yPos="100")
-
-        #     pm.FabricCanvasAddPort(mayaNode=spliceNode,
-        #                            execPath=kOperator.getName(),
-        #                            desiredPortName="solver",
-        #                            portType="IO",
-        #                            typeSpec=solverTypeName,
-        #                            connectToPortPath="",
-        #                            extDep=kOperator.getExtension())
-
-        #     pm.FabricCanvasAddPort(mayaNode=spliceNode,
-        #                            execPath="",
-        #                            desiredPortName="solver",
-        #                            portType="IO",
-        #                            typeSpec=solverTypeName,
-        #                            connectToPortPath="",
-        #                            extDep=kOperator.getExtension())
-
-        #     pm.FabricCanvasConnect(mayaNode=spliceNode,
-        #                            execPath="",
-        #                            srcPortPath="solver",
-        #                            dstPortPath=kOperator.getName() + ".solver")
-
-        #     pm.FabricCanvasConnect(mayaNode=spliceNode,
-        #                            execPath="",
-        #                            srcPortPath=kOperator.getName() + ".solver",
-        #                            dstPortPath="solver")
-
-        #     arraySizes = {}
-        #     # connect the operator to the objects in the DCC
-        #     args = kOperator.getSolverArgs()
-        #     for i in xrange(len(args)):
-        #         arg = args[i]
-        #         argName = arg.name.getSimpleType()
-        #         argDataType = arg.dataType.getSimpleType()
-        #         argConnectionType = arg.connectionType.getSimpleType()
-
-        #         if argConnectionType == 'In':
-        #             pm.FabricCanvasAddPort(mayaNode=spliceNode,
-        #                                    execPath="",
-        #                                    desiredPortName=argName,
-        #                                    portType="In",
-        #                                    typeSpec=argDataType,
-        #                                    connectToPortPath="")
-
-        #             pm.FabricCanvasAddPort(mayaNode=spliceNode,
-        #                                    execPath=kOperator.getName(),
-        #                                    desiredPortName=argName,
-        #                                    portType="In",
-        #                                    typeSpec=argDataType,
-        #                                    connectToPortPath="")
-
-        #             pm.FabricCanvasConnect(mayaNode=spliceNode,
-        #                                    execPath="",
-        #                                    srcPortPath=argName,
-        #                                    dstPortPath=kOperator.getName() + "." + argName)
-
-        #         elif argConnectionType in ['IO', 'Out']:
-        #             pm.FabricCanvasAddPort(
-        #                 mayaNode=spliceNode,
-        #                 execPath="",
-        #                 desiredPortName=argName,
-        #                 portType="Out",
-        #                 typeSpec=argDataType,
-        #                 connectToPortPath="")
-
-        #             pm.FabricCanvasAddPort(
-        #                 mayaNode=spliceNode,
-        #                 execPath=kOperator.getName(),
-        #                 desiredPortName=argName,
-        #                 portType="Out",
-        #                 typeSpec=argDataType,
-        #                 connectToPortPath="")
-
-        #             pm.FabricCanvasConnect(
-        #                 mayaNode=spliceNode,
-        #                 execPath="",
-        #                 srcPortPath=kOperator.getName() + "." + argName,
-        #                 dstPortPath=argName)
-        #         else:
-        #             raise Exception("Invalid connection type:" + portConnectionType)
-
-        #         if argDataType == 'EvalContext':
-        #             continue
-        #         if argName == 'time':
-        #             pm.expression(o=spliceNode + '.time', s=spliceNode + '.time = time;')
-        #             continue
-        #         if argName == 'frame':
-        #             pm.expression(o=spliceNode + '.frame', s=spliceNode + '.frame = frame;')
-        #             continue
-
-        #         # Get the argument's input from the DCC
-        #         if argConnectionType == 'In':
-        #             connectedObjects = kOperator.getInput(argName)
-        #         elif argConnectionType in ['IO', 'Out']:
-        #             connectedObjects = kOperator.getOutput(argName)
-
-        #         if argDataType.endswith('[]'):
-
-        #             # In SpliceMaya, output arrays are not resized by the
-        #             # system prior to calling into Splice, so we explicily
-        #             # resize the arrays in the generated operator stub code.
-        #             if argConnectionType in ['IO', 'Out']:
-        #                 arraySizes[argName] = len(connectedObjects)
-
-        #             connectionTargets = []
-        #             for i in xrange(len(connectedObjects)):
-        #                 opObject = connectedObjects[i]
-        #                 dccSceneItem = self.getDCCSceneItem(opObject)
-
-        #                 if hasattr(opObject, "getName"):
-        #                     # Handle output connections to visibility attributes.
-        #                     if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
-        #                         dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
-        #                         dccSceneItem = dccItem.attr('visibility')
-        #                     elif opObject.getName() == 'shapeVisibility' and opObject.getParent().getName() == 'implicitAttrGrp':
-        #                         dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
-        #                         shape = dccItem.getShape()
-        #                         dccSceneItem = shape.attr('visibility')
-
-        #                 connectionTargets.append(
-        #                     {
-        #                         'opObject': opObject,
-        #                         'dccSceneItem': dccSceneItem
-        #                     })
-        #         else:
-        #             if connectedObjects is None:
-        #                 if connectedObjects is None:
-        #                     logger.warning("Operator '" + kOperator.getName() +
-        #                                    "' of type '" + solverTypeName +
-        #                                    "' arg '" + argName + "' not connected.")
-        #                 continue
-
-        #             opObject = connectedObjects
-        #             dccSceneItem = self.getDCCSceneItem(opObject)
-        #             if hasattr(opObject, "getName"):
-        #                 # Handle output connections to visibility attributes.
-        #                 if opObject.getName() == 'visibility' and opObject.getParent().getName() == 'implicitAttrGrp':
-        #                     dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
-        #                     dccSceneItem = dccItem.attr('visibility')
-        #                 elif opObject.getName() == 'shapeVisibility' and opObject.getParent().getName() == 'implicitAttrGrp':
-        #                     dccItem = self.getDCCSceneItem(opObject.getParent().getParent())
-        #                     shape = dccItem.getShape()
-        #                     dccSceneItem = shape.attr('visibility')
-
-        #             connectionTargets = {
-        #                 'opObject': opObject,
-        #                 'dccSceneItem': dccSceneItem
-        #             }
-
-        #         # Add the Port for each arg.
-        #         if argConnectionType == 'In':
-
-        #             def connectInput(tgt, opObject, dccSceneItem):
-        #                 if isinstance(opObject, Attribute):
-        #                     pm.connectAttr(dccSceneItem, tgt)
-        #                 elif isinstance(opObject, Object3D):
-        #                     pm.connectAttr(dccSceneItem.attr('worldMatrix'), tgt)
-        #                 elif isinstance(opObject, Xfo):
-        #                     self.setMat44Attr(tgt.partition(".")[0], tgt.partition(".")[2], opObject.toMat44())
-        #                 elif isinstance(opObject, Mat44):
-        #                     self.setMat44Attr(tgt.partition(".")[0], tgt.partition(".")[2], opObject)
-        #                 elif isinstance(opObject, Vec2):
-        #                     pm.setAttr(tgt, opObject.x, opObject.y, type="double2")
-        #                 elif isinstance(opObject, Vec3):
-        #                     pm.setAttr(tgt, opObject.x, opObject.y, opObject.z, type="double3")
-        #                 else:
-        #                     validateArg(opObject, argName, argDataType)
-
-        #                     pm.setAttr(tgt, opObject)
-
-        #             if argDataType.endswith('[]'):
-        #                 for i in xrange(len(connectionTargets)):
-        #                     connectInput(
-        #                         spliceNode + "." + argName + '[' + str(i) + ']',
-        #                         connectionTargets[i]['opObject'],
-        #                         connectionTargets[i]['dccSceneItem'])
-        #             else:
-        #                 connectInput(
-        #                     spliceNode + "." + argName,
-        #                     connectionTargets['opObject'],
-        #                     connectionTargets['dccSceneItem'])
-
-        #         elif argConnectionType in ['IO', 'Out']:
-
-        #             def connectOutput(src, opObject, dccSceneItem):
-        #                 if isinstance(opObject, Attribute):
-        #                     pm.connectAttr(src, dccSceneItem, force=True)
-        #                 elif isinstance(opObject, Object3D):
-        #                     decomposeNode = pm.createNode('decomposeMatrix')
-        #                     pm.connectAttr(src,
-        #                                    decomposeNode.attr("inputMatrix"),
-        #                                    force=True)
-
-        #                     decomposeNode.attr("outputRotate").connect(dccSceneItem.attr("rotate"))
-        #                     decomposeNode.attr("outputScale").connect(dccSceneItem.attr("scale"))
-        #                     decomposeNode.attr("outputTranslate").connect(dccSceneItem.attr("translate"))
-        #                 elif isinstance(opObject, Xfo):
-        #                     raise NotImplementedError("Kraken KL Operator cannot set Xfo outputs types directly!")
-        #                 elif isinstance(opObject, Mat44):
-        #                     raise NotImplementedError("Kraken KL Operator cannot set Mat44 outputs types directly!")
-        #                 else:
-        #                     raise NotImplementedError("Kraken KL Operator cannot set outputs with Python built-in types directly!")
-
-        #             if argDataType.endswith('[]'):
-        #                 for i in xrange(len(connectionTargets)):
-        #                     connectOutput(
-        #                         str(spliceNode + "." + argName) + '[' + str(i) + ']',
-        #                         connectionTargets[i]['opObject'],
-        #                         connectionTargets[i]['dccSceneItem'])
-        #             else:
-        #                 connectOutput(
-        #                     str(spliceNode + "." + argName),
-        #                     connectionTargets['opObject'],
-        #                     connectionTargets['dccSceneItem'])
-
-        #     opSourceCode = kOperator.generateSourceCode(arraySizes=arraySizes)
-        #     pm.FabricCanvasSetCode(mayaNode=spliceNode,
-        #                            execPath=kOperator.getName(),
-        #                            code=opSourceCode)
-
-        # finally:
-        #     pass
 
         return True
 
@@ -1055,8 +796,8 @@ class Builder(Builder):
 
         """
 
-        def validateArg(rtVal, portName, portDataType):
-            """Validate argument types when passing built in Python types.
+        def validatePortValue(rtVal, portName, portDataType):
+            """Validate port value type when passing built in Python types.
 
             Args:
                 rtVal (RTVal): rtValue object.
@@ -1103,9 +844,9 @@ class Builder(Builder):
                 solverTypeName = kOperator.getSolverTypeName()
 
                 pm.FabricCanvasAddFunc(mayaNode=canvasNode,
-                                   execPath="",
-                                   title=kOperator.getName(),
-                                   code="dfgEntry {}", xPos="100", yPos="100")
+                                       execPath="",
+                                       title=kOperator.getName(),
+                                       code="dfgEntry {}", xPos="100", yPos="100")
 
                 pm.FabricCanvasAddPort(mayaNode=canvasNode,
                                        execPath=kOperator.getName(),
@@ -1133,6 +874,10 @@ class Builder(Builder):
                                        srcPortPath=kOperator.getName() + ".solver",
                                        dstPortPath="solver")
             else:
+                pm.FabricCanvasSetExtDeps(mayaNode=canvasNode,
+                                          execPath="",
+                                          extDep="Kraken")
+
                 graphNodeName = pm.FabricCanvasInstPreset(
                     mayaNode=canvasNode,
                     execPath="",
@@ -1180,7 +925,7 @@ class Builder(Builder):
                         pm.FabricCanvasConnect(mayaNode=canvasNode,
                                                execPath="",
                                                srcPortPath=portName,
-                                               dstPortPath=kOperator.getName() + "." + argName)
+                                               dstPortPath=kOperator.getName() + "." + portName)
 
                     else:
                         pm.FabricCanvasAddPort(
@@ -1204,7 +949,7 @@ class Builder(Builder):
                             execPath="",
                             desiredPortName=portName,
                             portType="Out",
-                            typeSpec=argDataType,
+                            typeSpec=portDataType,
                             connectToPortPath="")
 
                         pm.FabricCanvasAddPort(
@@ -1212,7 +957,7 @@ class Builder(Builder):
                             execPath=kOperator.getName(),
                             desiredPortName=portName,
                             portType="Out",
-                            typeSpec=argDataType,
+                            typeSpec=portDataType,
                             connectToPortPath="")
 
                         pm.FabricCanvasConnect(
@@ -1326,7 +1071,7 @@ class Builder(Builder):
                         elif isinstance(opObject, Vec3):
                             pm.setAttr(tgt, opObject.x, opObject.y, opObject.z, type="double3")
                         else:
-                            validateArg(opObject, portName, portDataType)
+                            validatePortValue(opObject, portName, portDataType)
 
                             pm.setAttr(tgt, opObject)
 
@@ -1377,7 +1122,7 @@ class Builder(Builder):
 
             if isKLBased is True:
                 opSourceCode = kOperator.generateSourceCode(arraySizes=arraySizes)
-                pm.FabricCanvasSetCode(mayaNode=spliceNode,
+                pm.FabricCanvasSetCode(mayaNode=canvasNode,
                                        execPath=kOperator.getName(),
                                        code=opSourceCode)
 

--- a/Python/kraken/plugins/si_plugin/builder.py
+++ b/Python/kraken/plugins/si_plugin/builder.py
@@ -1172,7 +1172,7 @@ class Builder(Builder):
 
 
             # Create Splice Operator
-            canvasOpPath = si.FabricCanvasOpApply(operatorOwner.FullName, "", True, "", "")
+            canvasOpPath = str(si.FabricCanvasOpApply(operatorOwner.FullName, "", True, "", ""))
             canvasOp = si.Dictionary.GetObject(canvasOpPath, False)
             self._registerSceneItemPair(kOperator, canvasOp)
 
@@ -1199,9 +1199,7 @@ class Builder(Builder):
                 if portDataType in ('Xfo', 'Mat44'):
                     portmapDefinition = portName + "|XSI Port"
 
-                    canvasOpPath2 = str(canvasOpPath) + ":"
                     si.FabricCanvasOpPortMapDefine(canvasOpPath, portmapDefinition)
-                    canvasOpPath = str(canvasOpPath2)[:-1]
                     canvasOp = si.Dictionary.GetObject(canvasOpPath, False)
 
                     si.FabricCanvasOpConnectPort(
@@ -1214,9 +1212,7 @@ class Builder(Builder):
                     if argConnectionType == 'In':
                         portmapDefinition = portName + "|XSI Parameter"
 
-                        canvasOpPath2 = str(canvasOpPath) + ":"
                         si.FabricCanvasOpPortMapDefine(canvasOpPath, portmapDefinition)
-                        canvasOpPath = str(canvasOpPath2)[:-1]
                         canvasOp = si.Dictionary.GetObject(canvasOpPath, False)
 
                         parameter = canvasOp.Parameters(portName)
@@ -1233,9 +1229,7 @@ class Builder(Builder):
                     elif argConnectionType in ('Out', 'IO'):
                         portmapDefinition = portName + "|XSI Port"
 
-                        canvasOpPath2 = str(canvasOpPath) + ":"
                         si.FabricCanvasOpPortMapDefine(canvasOpPath, portmapDefinition)
-                        canvasOpPath = str(canvasOpPath2)[:-1]
                         canvasOp = si.Dictionary.GetObject(canvasOpPath, False)
 
                         outParamProp = canvasOp.Parent3DObject.Properties("_CanvasOut_" + portName)
@@ -1259,46 +1253,48 @@ class Builder(Builder):
                 canvasOpPath2 = str(canvasOpPath) + ":"
 
                 if portDataType.endswith('[]'):
+                    arrayNode = None
+                    connectedObjects = None
                     elementDataType = portDataType[:-2]
                     if portConnectionType == 'In':
                         connectedObjects = kOperator.getInput(portName)
                         if connectedObjects is None:
                             continue
 
-                        arrayNode = si.FabricCanvasAddFunc(
-                            canvasOpPath,
-                            "",
-                            portName + "_ComposeArray",
-                            "dfgEntry {}",
-                            "40",
-                            str(i * 100))
+                        # arrayNode = si.FabricCanvasAddFunc(
+                        #     canvasOpPath,
+                        #     "",
+                        #     portName + "_ComposeArray",
+                        #     "dfgEntry {}",
+                        #     "40",
+                        #     str(i * 100))
 
-                        si.FabricCanvasAddPort(canvasOpPath,
-                                               arrayNode,
-                                               "array",
-                                               "Out",
-                                               portDataType,
-                                               "")
+                        # si.FabricCanvasAddPort(canvasOpPath,
+                        #                        arrayNode,
+                        #                        "array",
+                        #                        "Out",
+                        #                        portDataType,
+                        #                        "")
 
-                        arrayNodeCode = "dfgEntry { \n  array.resize(" + str(len(connectedObjects)) + ");\n"
-                        for j in xrange(len(connectedObjects)):
-                            si.FabricCanvasAddPort(canvasOpPath,
-                                                   arrayNode,
-                                                   "value" + str(j),
-                                                   "In",
-                                                   elementDataType,
-                                                   "",
-                                                   "")
+                        # arrayNodeCode = "dfgEntry { \n  array.resize(" + str(len(connectedObjects)) + ");\n"
+                        # for j in xrange(len(connectedObjects)):
+                        #     si.FabricCanvasAddPort(canvasOpPath,
+                        #                            arrayNode,
+                        #                            "value" + str(j),
+                        #                            "In",
+                        #                            elementDataType,
+                        #                            "",
+                        #                            "")
 
-                            arrayNodeCode += "  array[" + str(j) + "] = value" + str(j) + ";\n"
+                        #     arrayNodeCode += "  array[" + str(j) + "] = value" + str(j) + ";\n"
 
-                        arrayNodeCode += "}"
-                        si.FabricCanvasSetCode(canvasOpPath, arrayNode, arrayNodeCode)
+                        # arrayNodeCode += "}"
+                        # si.FabricCanvasSetCode(canvasOpPath, arrayNode, arrayNodeCode)
 
-                        si.FabricCanvasConnect(canvasOpPath,
-                                               "",
-                                               arrayNode + ".array",
-                                               uniqueNodeName + "." + portName)
+                        # si.FabricCanvasConnect(canvasOpPath,
+                        #                        "",
+                        #                        arrayNode + ".array",
+                        #                        uniqueNodeName + "." + portName)
 
                     elif portConnectionType in ['IO', 'Out']:
                         connectedObjects = kOperator.getOutput(portName)
@@ -1367,12 +1363,15 @@ class Builder(Builder):
                         # a new port.
                         canvasOp = si.Dictionary.GetObject(operatorOwner.Fullname + ".kine.global.CanvasOp", False)
 
-                        addCanvasPorts(canvasOp,
-                                       portName + str(j),
-                                       arrayNode + ".value" + str(j),
-                                       elementDataType,
-                                       portConnectionType,
-                                       dccSceneItem)
+                        if arrayNode is not None:
+
+                        else:
+                            addCanvasPorts(canvasOp,
+                                           portName + str(j),
+                                           arrayNode + ".value" + str(j),
+                                           elementDataType,
+                                           portConnectionType,
+                                           dccSceneItem)
 
                 else:
                     if portConnectionType == 'In':


### PR DESCRIPTION
Fixes #394

This merges the buildKLOperator and buildCanvasOperator methods into buildCanvasOperator(). A new argument was added `isKLBased` which is passed `True` for building KL based operators. This reduces the technical debt around making changes to how Fabric operators are built.