### PR TITLE
Joints now have a radius attribute

### DIFF
--- a/Python/kraken/core/configs/config.py
+++ b/Python/kraken/core/configs/config.py
@@ -21,11 +21,43 @@ class Config(object):
         Config.__instance = self
 
         self._explicitNaming = False
+        self._objectSettings = self.initObjectSettings()
         self._colors = self.initColors()
         self._colorMap = self.initColorMap()
         self._nameTemplate = self.initNameTemplate()
         self._controlShapes = self.initControlShapes()
         self._metaData = {}
+
+    # ================
+    # Object Settings
+    # ================
+    def initObjectSettings(self):
+        """Initializes default object settings to be applied when certain
+        objects are created.
+
+        Returns:
+            dict: object settings.
+
+        """
+
+        settings = {
+            "joint": {
+                "size": 1.0
+            }
+        }
+
+        return settings
+
+
+    def getObjectSettings(self):
+        """Gets the colors defined in the config.
+
+        Returns:
+            dict: colors.
+
+        """
+
+        return self._objectSettings
 
 
     # ==============

--- a/Python/kraken/core/objects/joint.py
+++ b/Python/kraken/core/objects/joint.py
@@ -12,18 +12,23 @@ from kraken.core.objects.object_3d import Object3D
 class Joint(Object3D):
     """Joint object."""
 
-    def __init__(self, name, parent=None):
+    def __init__(self, name, parent=None, **kwargs):
         super(Joint, self).__init__(name, parent=parent)
+        self._radius = 1.0
 
-        config = Config.getInstance()
-        objSettings = config.getObjectSettings()
-        jointSettings = objSettings.get('joint', None)
-        if jointSettings is None:
-            jointSize = 1.0
+        if 'radius' in kwargs:
+            jointRadius = kwargs['radius']
         else:
-            jointSize = jointSettings.get('size', 1.0)
+            config = Config.getInstance()
+            objSettings = config.getObjectSettings()
+            jointSettings = objSettings.get('joint', None)
+            if jointSettings is None:
+                jointRadius = 1.0
+            else:
+                jointRadius = jointSettings.get('size', 1.0)
 
-        self.radius = jointSize
+        self.setRadius(jointRadius)
+
 
     def getRadius(self):
         """Gets the radius of the joint.
@@ -33,7 +38,7 @@ class Joint(Object3D):
 
         """
 
-        return self.radius
+        return self._radius
 
     def setRadius(self, radius):
         """Sets the radius of the joint.
@@ -52,4 +57,4 @@ class Joint(Object3D):
         if type(radius) is int:
             radius = float(radius)
 
-        self.radius = radius
+        self._radius = radius

--- a/Python/kraken/core/objects/joint.py
+++ b/Python/kraken/core/objects/joint.py
@@ -5,6 +5,7 @@ Joint -- Joint representation.
 
 """
 
+from kraken.core.configs.config import Config
 from kraken.core.objects.object_3d import Object3D
 
 
@@ -13,3 +14,42 @@ class Joint(Object3D):
 
     def __init__(self, name, parent=None):
         super(Joint, self).__init__(name, parent=parent)
+
+        config = Config.getInstance()
+        objSettings = config.getObjectSettings()
+        jointSettings = objSettings.get('joint', None)
+        if jointSettings is None:
+            jointSize = 1.0
+        else:
+            jointSize = jointSettings.get('size', 1.0)
+
+        self.radius = jointSize
+
+    def getRadius(self):
+        """Gets the radius of the joint.
+
+        Returns:
+            float: Radius of the joint.
+
+        """
+
+        return self.radius
+
+    def setRadius(self, radius):
+        """Sets the radius of the joint.
+
+        Args:
+            radiu (float): Radius to set the joint to.
+
+        Returns:
+            bool: True if successful.
+
+        """
+
+        assert type(radius) in (int, float), "Joint.setRadius() argument value" \
+            "is of type '" + type(radius).__name__ + "' , not of type (int, float)"
+
+        if type(radius) is int:
+            radius = float(radius)
+
+        self.radius = radius

--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -184,6 +184,8 @@ class Builder(Builder):
         dccSceneItem = pm.joint(name="joint")
         pm.rename(dccSceneItem, buildName)
 
+        radius = dccSceneItem.attr('radius').set(kSceneItem.getRadius())
+
         self._registerSceneItemPair(kSceneItem, dccSceneItem)
 
         return dccSceneItem

--- a/Python/kraken/plugins/si_plugin/builder.py
+++ b/Python/kraken/plugins/si_plugin/builder.py
@@ -189,7 +189,7 @@ class Builder(Builder):
 
         dccSceneItem = parentDCCSceneItem.AddNull()
         dccSceneItem.Parameters('primary_icon').Value = 2
-        dccSceneItem.Parameters('size').Value = 0.125
+        dccSceneItem.Parameters('size').Value = kSceneItem.getRadius()
         dccSceneItem.Name = buildName
         self._registerSceneItemPair(kSceneItem, dccSceneItem)
 


### PR DESCRIPTION
Joints now have a radius attribute that can be set via the `radius` keyword argument or `setRadius()` method. Also a `getRadius()` method is available to query as well.

The Joint object now looks for settings in the config to set it's default radius to if the radius isn't set via the keyword argument as well.

Fixes #352 