### PR TITLE
KL solver var node

### DIFF
--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -915,19 +915,6 @@ class Builder(Builder):
                                        srcPortPath=solverVarName + ".value",
                                        dstPortPath=solverSolveNodeName + ".solver")
 
-                # pm.FabricCanvasAddPort(mayaNode=canvasNode,
-                #                        execPath="",
-                #                        desiredPortName="solver",
-                #                        portType="IO",
-                #                        typeSpec=solverTypeName,
-                #                        connectToPortPath="",
-                #                        extDep=kOperator.getExtension())
-
-                # pm.FabricCanvasConnect(mayaNode=canvasNode,
-                #                        execPath="",
-                #                        srcPortPath="solver",
-                #                        dstPortPath=solverNodeName + ".solver")
-
                 pm.FabricCanvasConnect(mayaNode=canvasNode,
                                        execPath="",
                                        srcPortPath=solverSolveNodeName + ".solver",


### PR DESCRIPTION
Removes the solver port from the top canvas node and uses a new function node and variable node to host the solver for KL based solvers.

Closes #430 