### PR TITLE
Operator Constraint Eval Check

### DIFF
--- a/Python/kraken/core/objects/constraints/constraint.py
+++ b/Python/kraken/core/objects/constraints/constraint.py
@@ -353,6 +353,8 @@ class Constraint(SceneItem):
 
         """
 
+        self.setFlag("HAS_EVALUATED")
+
         if self.getMaintainOffset() is False:
             self.getConstrainee().xfo = self.compute()
             return True

--- a/Python/kraken/core/objects/operators/operator.py
+++ b/Python/kraken/core/objects/operators/operator.py
@@ -412,5 +412,6 @@ class Operator(SceneItem):
         """
 
         self.updateTargets()
+        self.setFlag("HAS_EVALUATED")
 
         return True


### PR DESCRIPTION
Builder now checks ops and constraints have evaluated. If not, warnings are printed in the log.

Fixes #321 