### PR TITLE
Develop oss connect op output to attr fix

### DIFF
--- a/Python/kraken/core/objects/operators/canvas_operator.py
+++ b/Python/kraken/core/objects/operators/canvas_operator.py
@@ -71,7 +71,7 @@ class CanvasOperator(Operator):
 
         rtVal = self.node.getPortDefaultValue(name, RTValDataType)
 
-        logger.info("Using default value for %s.%s.%s(%s) --> %s" % (self.canvasPresetPath, self.getName(), mode, name, rtVal))
+        logger.debug("Using default value for %s.%s.%s(%s) --> %s" % (self.canvasPresetPath, self.getName(), mode, name, rtVal))
 
         return rtVal
 

--- a/Python/kraken/core/objects/operators/kl_operator.py
+++ b/Python/kraken/core/objects/operators/kl_operator.py
@@ -136,7 +136,7 @@ class KLOperator(Operator):
                 # when we run it on it's own and use the type that we query.  Gotta investigate this further...
                 RTVal = ks.convertFromRTVal(self.solverRTVal.defaultValues[name], RTTypeName=RTValDataType)
 
-            logger.info("Using default value for %s.%s.%s(%s) --> %s" % (self.solverTypeName, self.getName(), mode, name, RTVal))
+            logger.debug("Using default value for %s.%s.%s(%s) --> %s" % (self.solverTypeName, self.getName(), mode, name, RTVal))
             return RTVal
 
         else:
@@ -401,7 +401,10 @@ class KLOperator(Operator):
             elif isinstance(obj, Mat44):
                 obj.setFromMat44(rtval)
             elif isinstance(obj, Attribute):
-                obj.setValue(rtval)
+                if ks.isRTVal(rtval):
+                    obj.setValue(rtval.getSimpleType())
+                else:
+                    obj.setValue(rtval)
             else:
                 if hasattr(obj, '__iter__'):
                     logger.warning("Warning: Trying to set a KL port with an array directly.")
@@ -416,10 +419,12 @@ class KLOperator(Operator):
             argConnectionType = arg.connectionType.getSimpleType()
 
             if argConnectionType != 'In':
-                if str(argDataType).endswith('[]'):
-                    for j in xrange(len(argVals[i])):
-                        setRTVal(self.outputs[argName][j], argVals[i][j])
-                elif argName in self.outputs and self.outputs[argName] is not None:
+                if argName in self.outputs and self.outputs[argName] is not None:
+                    if str(argDataType).endswith('[]'):
+                        for j in xrange(len(argVals[i])):
+                            if len(self.outputs[argName]) > j and self.outputs[argName][j] is not None:
+                                setRTVal(self.outputs[argName][j], argVals[i][j])
+                    else:
                         setRTVal(self.outputs[argName], argVals[i])
 
         return True

--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -1143,7 +1143,10 @@ class Builder(Builder):
 
                     def connectOutput(src, opObject, dccSceneItem):
                         if isinstance(opObject, Attribute):
+                            locked = dccSceneItem.isLocked()
+                            dccSceneItem.unlock()
                             pm.connectAttr(src, dccSceneItem)
+                            dccSceneItem.setLocked(locked)
                         elif isinstance(opObject, Object3D):
                             decomposeNode = pm.createNode('decomposeMatrix')
                             pm.connectAttr(src,


### PR DESCRIPTION
* Added ability to directly connect the output of an operator to an attribute.  Needed to convert from RVType.

* Fixed but where there is an operator output array that is not connected to anything.

* Fixed bug where can't connect to an attribute and also lock that attribute

* Also, turned off verbose output for default value use.  Too noisy.