### PR TITLE
Maya Parallel Eval on by Default

### DIFF
--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -1182,6 +1182,9 @@ class Builder(Builder):
                                        execPath=solverSolveNodeName,
                                        code=opSourceCode)
 
+            if kOperator.testFlag('disableParallelEval') is False:
+                pm.FabricCanvasSetExecuteShared(mayaNode=canvasNode, enable=True)
+
         finally:
             pass
 


### PR DESCRIPTION
Maya builder now looks for the 'disableParallelEval' flag on Canvas operators to not enable the Parallel Eval.

Parallel eval is on by default in Kraken

@todderasesareddot @bhaux 