### PR TITLE
FE-7857 Take 2

### DIFF
--- a/Python/kraken/core/maths/__init__.py
+++ b/Python/kraken/core/maths/__init__.py
@@ -11,29 +11,7 @@ from mat33 import Mat33
 from mat44 import Mat44
 from rotation_order import RotationOrder
 from color import Color
-
-
-PI = 3.141592653589793
-DEG_TO_RAD = 0.017453292519943295
-RAD_TO_DEG = 57.29577951308232
-
-AXIS_NAME_TO_TUPLE_MAP = {
-    'POSX': (1, 0, 0),
-    'POSY': (0, 1, 0),
-    'POSZ': (0, 0, 1),
-    'NEGX': (-1, 0, 0),
-    'NEGY': (0, -1, 0),
-    'NEGZ': (0, 0, -1)
-}
-
-AXIS_NAME_TO_INT_MAP = {
-    'POSX': 0,
-    'POSY': 1,
-    'POSZ': 2,
-    'NEGX': 3,
-    'NEGY': 4,
-    'NEGZ': 5
-}
+from constants import DEG_TO_RAD, RAD_TO_DEG
 
 
 def Math_radToDeg(val):

--- a/Python/kraken/core/maths/constants.py
+++ b/Python/kraken/core/maths/constants.py
@@ -39,10 +39,10 @@ ROT_ORDER_STR_TO_INT_MAP = {
 }
 
 ROT_ORDER_INT_TO_STR_MAP = {
-    'ZYX': 0,
-    'XZY': 1,
-    'YXZ': 2,
-    'YZX': 3,
-    'XYZ': 4,
-    'ZXY': 5
+    0: 'ZYX',
+    1: 'XZY',
+    2: 'YXZ',
+    3: 'YZX',
+    4: 'XYZ',
+    5: 'ZXY'
 }

--- a/Python/kraken/core/maths/constants.py
+++ b/Python/kraken/core/maths/constants.py
@@ -1,0 +1,48 @@
+"""Kraken - math.constants module."""
+
+
+PI = 3.141592653589793
+DEG_TO_RAD = 0.017453292519943295
+RAD_TO_DEG = 57.29577951308232
+
+AXIS_NAME_TO_TUPLE_MAP = {
+    'POSX': (1, 0, 0),
+    'POSY': (0, 1, 0),
+    'POSZ': (0, 0, 1),
+    'NEGX': (-1, 0, 0),
+    'NEGY': (0, -1, 0),
+    'NEGZ': (0, 0, -1)
+}
+
+AXIS_NAME_TO_INT_MAP = {
+    'POSX': 0,
+    'POSY': 1,
+    'POSZ': 2,
+    'NEGX': 3,
+    'NEGY': 4,
+    'NEGZ': 5
+}
+
+ROT_ORDER_STR_TO_INT_MAP = {
+    'zyx': 0,
+    'ZYX': 0,
+    'xzy': 1,
+    'XZY': 1,
+    'yxz': 2,
+    'YXZ': 2,
+    'yzx': 3,
+    'YZX': 3,
+    'xyz': 4,
+    'XYZ': 4,
+    'zxy': 5,
+    'ZXY': 5
+}
+
+ROT_ORDER_INT_TO_STR_MAP = {
+    'ZYX': 0,
+    'XZY': 1,
+    'YXZ': 2,
+    'YZX': 3,
+    'XYZ': 4,
+    'ZXY': 5
+}

--- a/Python/kraken/core/maths/euler.py
+++ b/Python/kraken/core/maths/euler.py
@@ -12,31 +12,6 @@ from kraken.core.maths.mat33 import Mat33
 from kraken.core.maths.rotation_order import RotationOrder
 
 
-rotationOrderStrToIntMapping = {
-    'xyz': 0,
-    'XYZ': 0,
-    'yzx': 1,
-    'YZX': 1,
-    'zxy': 2,
-    'ZXY': 2,
-    'xzy': 3,
-    'XZY': 3,
-    'zyx': 4,
-    'ZYX': 4,
-    'yxz': 5,
-    'YXZ': 5
-}
-
-rotationOrderIntToStrMapping = [
-    'XYZ',
-    'YZX',
-    'ZXY',
-    'XZY',
-    'ZYX',
-    'YXZ'
-]
-
-
 class Euler(MathObject):
     """Euler rotation object."""
 

--- a/Python/kraken/core/maths/rotation_order.py
+++ b/Python/kraken/core/maths/rotation_order.py
@@ -65,7 +65,7 @@ class RotationOrder(MathObject):
 
         """
 
-        self.set(order=value)
+        self._rtval.order = ks.rtVal('Integer', value)
 
         return True
 
@@ -109,7 +109,7 @@ class RotationOrder(MathObject):
                 newOrder = 4
 
         elif type(order) == int:
-            if order not in ROT_ORDER_INT_TO_STR_MAP:
+            if order not in ROT_ORDER_INT_TO_STR_MAP.values():
                 print "Invalid rotation order: '" + str(order) + "', using default 4 (XYZ)."
                 newOrder = 4
             else:
@@ -220,7 +220,7 @@ class RotationOrder(MathObject):
 
         """
 
-        self.order = 0
+        self._rtval.setZYX('')
 
         return True
 
@@ -233,7 +233,7 @@ class RotationOrder(MathObject):
 
         """
 
-        self.order = 1
+        self._rtval.setXZY('')
 
         return True
 
@@ -246,7 +246,7 @@ class RotationOrder(MathObject):
 
         """
 
-        self.order = 2
+        self._rtval.setYXZ('')
 
         return True
 
@@ -259,7 +259,7 @@ class RotationOrder(MathObject):
 
         """
 
-        self.order = 3
+        self._rtval.setYZX('')
 
         return True
 
@@ -272,7 +272,7 @@ class RotationOrder(MathObject):
 
         """
 
-        self.order = 4
+        self._rtval.setXYZ('')
 
         return True
 
@@ -285,6 +285,6 @@ class RotationOrder(MathObject):
 
         """
 
-        self.order = 5
+        self._rtval.setZXY('')
 
         return True

--- a/Python/kraken/core/maths/rotation_order.py
+++ b/Python/kraken/core/maths/rotation_order.py
@@ -6,6 +6,8 @@ RotationOrder -- Rotation Order.
 
 import math
 
+from kraken.core.maths.constants import ROT_ORDER_INT_TO_STR_MAP
+from kraken.core.maths.constants import ROT_ORDER_STR_TO_INT_MAP
 from kraken.core.kraken_system import ks
 from kraken.core.maths.math_object import MathObject
 
@@ -13,7 +15,7 @@ from kraken.core.maths.math_object import MathObject
 class RotationOrder(MathObject):
     """RotationOrder rotation object."""
 
-    def __init__(self, order=0):
+    def __init__(self, order=4):
         """Initialize rotation order."""
 
         super(RotationOrder, self).__init__()
@@ -100,95 +102,37 @@ class RotationOrder(MathObject):
 
         """
 
-        newOrder = 0
-
         if type(order) == str:
-            lowerOrder = order.lower()
-            if lowerOrder == 'xyz':
-                newOrder = 0
-            elif lowerOrder == 'yzx':
-                newOrder = 1
-            elif lowerOrder == 'zxy':
-                newOrder = 2
-            elif lowerOrder == 'xzy':
-                newOrder = 3
-            elif lowerOrder == 'zyx':
+            newOrder = ROT_ORDER_STR_TO_INT_MAP.get(order, -1)
+            if newOrder == -1:
+                print "Invalid rotation order '" + order + "', using default 4 (XYZ)."
                 newOrder = 4
-            elif lowerOrder == 'yxz':
-                newOrder = 5
-            else:
-                print "Invalid rotation order '" + order + "', using default 0 (XYZ)."
-                newOrder = 0
 
         elif type(order) == int:
-            if order < 0 or order > 5:
-                print "Invalid rotation order: '" + str(order) + "', using default 0 (XYZ)."
-                newOrder = 0
+            if order not in ROT_ORDER_INT_TO_STR_MAP:
+                print "Invalid rotation order: '" + str(order) + "', using default 4 (XYZ)."
+                newOrder = 4
             else:
                 newOrder = order
         else:
             raise NotImplementedError("Cannot set rotation order with type: " + str(type(order)))
 
         if newOrder == 0:
-            self._rtval.setXYZ('')
-        elif newOrder == 1:
-            self._rtval.setYZX('')
-        elif newOrder == 2:
-            self._rtval.setZXY('')
-        elif newOrder == 3:
-            self._rtval.setXZY('')
-        elif newOrder == 4:
             self._rtval.setZYX('')
-        elif newOrder == 5:
+        elif newOrder == 1:
+            self._rtval.setXZY('')
+        elif newOrder == 2:
             self._rtval.setYXZ('')
+        elif newOrder == 3:
+            self._rtval.setYZX('')
+        elif newOrder == 4:
+            self._rtval.setXYZ('')
+        elif newOrder == 5:
+            self._rtval.setZXY('')
         else:
             raise ValueError("Invalid rotation order: '" + str(order) + "'")
 
         return True
-
-
-    def isXYZ(self):
-        """Checks if this Rotation Order is equal to XYZ.
-
-        Returns:
-            bool: True if this rotationorder is XYZ.
-
-        """
-
-        return self.order == 0
-
-
-    def isYZX(self):
-        """Checks if this Rotation Order is equal to YZX.
-
-        Returns:
-            bool: True if this rotationorder is YZX.
-
-        """
-
-        return self.order == 1
-
-
-    def isZXY(self):
-        """Checks if this Rotation Order is equal to ZXY.
-
-        Returns:
-            bool: True if this rotationorder is ZXY.
-
-        """
-
-        return self.order == 2
-
-
-    def isXZY(self):
-        """Checks if this Rotation Order is equal to XZY.
-
-        Returns:
-            bool: True if this rotationorder is XZY.
-
-        """
-
-        return self.order == 3
 
 
     def isZYX(self):
@@ -199,7 +143,18 @@ class RotationOrder(MathObject):
 
         """
 
-        return self.order == 4
+        return self.order == 0
+
+
+    def isXZY(self):
+        """Checks if this Rotation Order is equal to XZY.
+
+        Returns:
+            bool: True if this rotationorder is XZY.
+
+        """
+
+        return self.order == 1
 
 
     def isYXZ(self):
@@ -207,6 +162,39 @@ class RotationOrder(MathObject):
 
         Returns:
             bool: True if this rotationorder is YXZ.
+
+        """
+
+        return self.order == 2
+
+
+    def isYZX(self):
+        """Checks if this Rotation Order is equal to YZX.
+
+        Returns:
+            bool: True if this rotationorder is YZX.
+
+        """
+
+        return self.order == 3
+
+
+    def isXYZ(self):
+        """Checks if this Rotation Order is equal to XYZ.
+
+        Returns:
+            bool: True if this rotationorder is XYZ.
+
+        """
+
+        return self.order == 4
+
+
+    def isZXY(self):
+        """Checks if this Rotation Order is equal to ZXY.
+
+        Returns:
+            bool: True if this rotationorder is ZXY.
 
         """
 
@@ -224,8 +212,8 @@ class RotationOrder(MathObject):
         return self.isXZY() or self.isZYX() or self.isYXZ()
 
 
-    def setXYZ(self):
-        """Sets this rotation order to be XYZ.
+    def setZYX(self):
+        """Sets this rotation order to be ZYX.
 
         Returns:
             bool: True if successful.
@@ -233,32 +221,6 @@ class RotationOrder(MathObject):
         """
 
         self.order = 0
-
-        return True
-
-
-    def setYZX(self):
-        """Sets this rotation order to be YZX.
-
-        Returns:
-            bool: True if successful.
-
-        """
-
-        self.order = 1
-
-        return True
-
-
-    def setZXY(self):
-        """Sets this rotation order to be ZXY.
-
-        Returns:
-            bool: True if successful.
-
-        """
-
-        self.order = 2
 
         return True
 
@@ -271,13 +233,39 @@ class RotationOrder(MathObject):
 
         """
 
+        self.order = 1
+
+        return True
+
+
+    def setYXZ(self):
+        """Sets this rotation order to be YXZ.
+
+        Returns:
+            bool: True if successful.
+
+        """
+
+        self.order = 2
+
+        return True
+
+
+    def setYZX(self):
+        """Sets this rotation order to be YZX.
+
+        Returns:
+            bool: True if successful.
+
+        """
+
         self.order = 3
 
         return True
 
 
-    def setZYX(self):
-        """Sets this rotation order to be ZYX.
+    def setXYZ(self):
+        """Sets this rotation order to be XYZ.
 
         Returns:
             bool: True if successful.
@@ -289,8 +277,8 @@ class RotationOrder(MathObject):
         return True
 
 
-    def setYXZ(self):
-        """Sets this rotation order to be YXZ.
+    def setZXY(self):
+        """Sets this rotation order to be ZXY.
 
         Returns:
             bool: True if successful.

--- a/Python/kraken/core/maths/rotation_order.py
+++ b/Python/kraken/core/maths/rotation_order.py
@@ -63,7 +63,7 @@ class RotationOrder(MathObject):
 
         """
 
-        self._rtval.order = ks.rtVal('Integer', value)
+        self.set(order=value)
 
         return True
 

--- a/Python/kraken/core/objects/control.py
+++ b/Python/kraken/core/objects/control.py
@@ -6,7 +6,8 @@ Control - Base Control.
 """
 
 from kraken.core.configs.config import Config
-from kraken.core.maths import AXIS_NAME_TO_TUPLE_MAP, Euler, Quat, Vec3, Xfo
+from kraken.core.maths.constants import AXIS_NAME_TO_TUPLE_MAP
+from kraken.core.maths import Euler, Quat, Vec3, Xfo
 from kraken.core.maths import Math_degToRad
 from kraken.core.objects.curve import Curve
 from kraken.core.objects.ctrlSpace import CtrlSpace

--- a/Python/kraken/plugins/max_plugin/builder.py
+++ b/Python/kraken/plugins/max_plugin/builder.py
@@ -2222,14 +2222,26 @@ class Builder(Builder):
 
         dccSceneItem.SetWorldTM(mat3)
 
+        # Rotation order remapping
+        # Max's enums don't map directly to the Fabric rotation orders
+        #
+        # Fabric | Max
+        # ---------------
+        # 0 ZYX  | 6 ZYX
+        # 1 XZY  | 2 XZY
+        # 2 YXZ  | 4 YXZ
+        # 3 YZX  | 3 YZX
+        # 4 XYZ  | 1 XYZ
+        # 5 ZXY  | 5 ZXY
+
         rotOrderRemap = {
-                0: 1,
-                1: 3,
-                2: 5,
-                3: 2,
-                4: 6,
-                5: 4
-            }
+            0: 6,
+            1: 2,
+            2: 4,
+            3: 3,
+            4: 1,
+            5: 5
+        }
 
         order = rotOrderRemap[kSceneItem.ro.order]
 

--- a/Python/kraken/plugins/max_plugin/builder.py
+++ b/Python/kraken/plugins/max_plugin/builder.py
@@ -31,6 +31,27 @@ from kraken.helpers.utility_methods import prepareToSave, prepareToLoad
 logger = getLogger('kraken')
 logger.setLevel(logging.INFO)
 
+# Rotation order remapping
+# Max's enums don't map directly to the Fabric rotation orders
+#
+# Fabric | Max
+# ---------------
+# 0 ZYX  | 6 ZYX
+# 1 XZY  | 2 XZY
+# 2 YXZ  | 4 YXZ
+# 3 YZX  | 3 YZX
+# 4 XYZ  | 1 XYZ
+# 5 ZXY  | 5 ZXY
+
+ROT_ORDER_REMAP = {
+    0: 6,
+    1: 2,
+    2: 4,
+    3: 3,
+    4: 1,
+    5: 5
+}
+
 
 class Builder(Builder):
     """Builder object for building Kraken objects in Maya."""
@@ -2222,28 +2243,7 @@ class Builder(Builder):
 
         dccSceneItem.SetWorldTM(mat3)
 
-        # Rotation order remapping
-        # Max's enums don't map directly to the Fabric rotation orders
-        #
-        # Fabric | Max
-        # ---------------
-        # 0 ZYX  | 6 ZYX
-        # 1 XZY  | 2 XZY
-        # 2 YXZ  | 4 YXZ
-        # 3 YZX  | 3 YZX
-        # 4 XYZ  | 1 XYZ
-        # 5 ZXY  | 5 ZXY
-
-        rotOrderRemap = {
-            0: 6,
-            1: 2,
-            2: 4,
-            3: 3,
-            4: 1,
-            5: 5
-        }
-
-        order = rotOrderRemap[kSceneItem.ro.order]
+        order = ROT_ORDER_REMAP[kSceneItem.ro.order]
 
         dccSceneItem.Select()
         MaxPlus.Core.EvalMAXScript('tgtObj = selection[1]')

--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -24,8 +24,30 @@ from kraken.helpers.utility_methods import prepareToSave, prepareToLoad
 
 import maya.cmds as cmds
 
+
 logger = getLogger('kraken')
 logger.setLevel(logging.INFO)
+
+# Rotation order remapping
+# Maya's enums don't map directly to the Fabric rotation orders
+#
+# Fabric | Maya
+# ---------------
+# 0 ZYX  | 5 ZYX
+# 1 XZY  | 3 XZY
+# 2 YXZ  | 4 YXZ
+# 3 YZX  | 1 YZX
+# 4 XYZ  | 0 XYZ
+# 5 ZXY  | 2 ZXY
+
+ROT_ORDER_REMAP = {
+    0: 5,
+    1: 3,
+    2: 4,
+    3: 1,
+    4: 0,
+    5: 2
+}
 
 
 class Builder(Builder):
@@ -579,28 +601,7 @@ class Builder(Builder):
 
             if kConstraint.getMaintainOffset() is True:
 
-                # Rotation order remapping
-                # Maya's enums don't map directly to the Fabric rotation orders
-                #
-                # Fabric | Maya
-                # ---------------
-                # 0 ZYX  | 5 ZYX
-                # 1 XZY  | 3 XZY
-                # 2 YXZ  | 4 YXZ
-                # 3 YZX  | 1 YZX
-                # 4 XYZ  | 0 XYZ
-                # 5 ZXY  | 2 ZXY
-
-                rotOrderRemap = {
-                    0: 5,
-                    1: 3,
-                    2: 4,
-                    3: 1,
-                    4: 0,
-                    5: 2
-                }
-
-                order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
+                order = ROT_ORDER_REMAP[kConstraint.getConstrainee().ro.order]
 
                 offsetXfo = kConstraint.computeOffset()
                 offsetAngles = offsetXfo.ori.toEulerAnglesWithRotOrder(
@@ -684,28 +685,7 @@ class Builder(Builder):
 
             if kConstraint.getMaintainOffset() is True:
 
-                # Rotation order remapping
-                # Maya's enums don't map directly to the Fabric rotation orders
-                #
-                # Fabric | Maya
-                # ---------------
-                # 0 ZYX  | 5 ZYX
-                # 1 XZY  | 3 XZY
-                # 2 YXZ  | 4 YXZ
-                # 3 YZX  | 1 YZX
-                # 4 XYZ  | 0 XYZ
-                # 5 ZXY  | 2 ZXY
-
-                rotOrderRemap = {
-                    0: 5,
-                    1: 3,
-                    2: 4,
-                    3: 1,
-                    4: 0,
-                    5: 2
-                }
-
-                order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
+                order = ROT_ORDER_REMAP[kConstraint.getConstrainee().ro.order]
 
                 offsetXfo = kConstraint.computeOffset()
                 offsetAngles = offsetXfo.ori.toEulerAnglesWithRotOrder(
@@ -1515,28 +1495,7 @@ class Builder(Builder):
 
         dccSceneItem.setRotation(quat, "world")
 
-        # Rotation order remapping
-        # Maya's enums don't map directly to the Fabric rotation orders
-        #
-        # Fabric | Maya
-        # ---------------
-        # 0 ZYX  | 5 ZYX
-        # 1 XZY  | 3 XZY
-        # 2 YXZ  | 4 YXZ
-        # 3 YZX  | 1 YZX
-        # 4 XYZ  | 0 XYZ
-        # 5 ZXY  | 2 ZXY
-
-        rotOrderRemap = {
-            0: 5,
-            1: 3,
-            2: 4,
-            3: 1,
-            4: 0,
-            5: 2
-        }
-
-        order = rotOrderRemap[kSceneItem.ro.order]
+        order = ROT_ORDER_REMAP[kSceneItem.ro.order]
 
         #  Maya api is one off from Maya's own node enum pyMel uses API
         dccSceneItem.setRotationOrder(order + 1, False)

--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -579,18 +579,28 @@ class Builder(Builder):
 
             if kConstraint.getMaintainOffset() is True:
 
-                # Maya's rotation order enums:
-                # 0 XYZ
-                # 1 YZX
-                # 2 ZXY
-                # 3 XZY
-                # 4 YXZ <-- 5 in Fabric
-                # 5 ZYX <-- 4 in Fabric
-                order = kConstraint.getConstrainee().ro.order
-                if order == 4:
-                    order = 5
-                elif order == 5:
-                    order = 4
+                # Rotation order remapping
+                # Maya's enums don't map directly to the Fabric rotation orders
+                #
+                # Fabric | Maya
+                # ---------------
+                # 0 ZYX  | 5 ZYX
+                # 1 XZY  | 3 XZY
+                # 2 YXZ  | 4 YXZ
+                # 3 YZX  | 1 YZX
+                # 4 XYZ  | 0 XYZ
+                # 5 ZXY  | 2 ZXY
+
+                roFabricToMayaRemap = {
+                    0: 5,
+                    1: 3,
+                    2: 4,
+                    3: 1,
+                    4: 0,
+                    5: 2
+                }
+
+                order = roFabricToMayaRemap[kConstraint.getConstrainee().ro.order]
 
                 offsetXfo = kConstraint.computeOffset()
                 offsetAngles = offsetXfo.ori.toEulerAnglesWithRotOrder(
@@ -674,31 +684,28 @@ class Builder(Builder):
 
             if kConstraint.getMaintainOffset() is True:
 
-                # Fabric's rotation order enums:
-                # We need to use the negative rotation order
-                # to calculate propery offset values.
+                # Rotation order remapping
+                # Maya's enums don't map directly to the Fabric rotation orders
                 #
-                # 0 XYZ
-                # 1 YZX
-                # 2 ZXY
-                # 3 XZY
-                # 4 ZYX
-                # 5 YXZ
+                # Fabric | Maya
+                # ---------------
+                # 0 ZYX  | 5 ZYX
+                # 1 XZY  | 3 XZY
+                # 2 YXZ  | 4 YXZ
+                # 3 YZX  | 1 YZX
+                # 4 XYZ  | 0 XYZ
+                # 5 ZXY  | 2 ZXY
 
-                rotOrderRemap = {
-                    0: 4,
+                roFabricToMayaRemap = {
+                    0: 5,
                     1: 3,
-                    2: 5,
+                    2: 4,
                     3: 1,
                     4: 0,
                     5: 2
                 }
 
-                order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
-                if order == 4:
-                    order = 5
-                elif order == 5:
-                    order = 4
+                order = roFabricToMayaRemap[kConstraint.getConstrainee().ro.order]
 
                 offsetXfo = kConstraint.computeOffset()
                 offsetAngles = offsetXfo.ori.toEulerAnglesWithRotOrder(
@@ -1508,18 +1515,28 @@ class Builder(Builder):
 
         dccSceneItem.setRotation(quat, "world")
 
-        # Maya's rotation order enums:
-        # 0 XYZ
-        # 1 YZX
-        # 2 ZXY
-        # 3 XZY
-        # 4 YXZ <-- 5 in Fabric
-        # 5 ZYX <-- 4 in Fabric
-        order = kSceneItem.ro.order
-        if order == 4:
-            order = 5
-        elif order == 5:
-            order = 4
+        # Rotation order remapping
+        # Maya's enums don't map directly to the Fabric rotation orders
+        #
+        # Fabric | Maya
+        # ---------------
+        # 0 ZYX  | 5 ZYX
+        # 1 XZY  | 3 XZY
+        # 2 YXZ  | 4 YXZ
+        # 3 YZX  | 1 YZX
+        # 4 XYZ  | 0 XYZ
+        # 5 ZXY  | 2 ZXY
+
+        roFabricToMayaRemap = {
+            0: 5,
+            1: 3,
+            2: 4,
+            3: 1,
+            4: 0,
+            5: 2
+        }
+
+        order = roFabricToMayaRemap[kSceneItem.ro.order]
 
         #  Maya api is one off from Maya's own node enum pyMel uses API
         dccSceneItem.setRotationOrder(order + 1, False)

--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -591,7 +591,7 @@ class Builder(Builder):
                 # 4 XYZ  | 0 XYZ
                 # 5 ZXY  | 2 ZXY
 
-                roFabricToMayaRemap = {
+                rotOrderRemap = {
                     0: 5,
                     1: 3,
                     2: 4,
@@ -600,7 +600,7 @@ class Builder(Builder):
                     5: 2
                 }
 
-                order = roFabricToMayaRemap[kConstraint.getConstrainee().ro.order]
+                order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
 
                 offsetXfo = kConstraint.computeOffset()
                 offsetAngles = offsetXfo.ori.toEulerAnglesWithRotOrder(
@@ -696,7 +696,7 @@ class Builder(Builder):
                 # 4 XYZ  | 0 XYZ
                 # 5 ZXY  | 2 ZXY
 
-                roFabricToMayaRemap = {
+                rotOrderRemap = {
                     0: 5,
                     1: 3,
                     2: 4,
@@ -705,7 +705,7 @@ class Builder(Builder):
                     5: 2
                 }
 
-                order = roFabricToMayaRemap[kConstraint.getConstrainee().ro.order]
+                order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
 
                 offsetXfo = kConstraint.computeOffset()
                 offsetAngles = offsetXfo.ori.toEulerAnglesWithRotOrder(
@@ -1527,7 +1527,7 @@ class Builder(Builder):
         # 4 XYZ  | 0 XYZ
         # 5 ZXY  | 2 ZXY
 
-        roFabricToMayaRemap = {
+        rotOrderRemap = {
             0: 5,
             1: 3,
             2: 4,
@@ -1536,7 +1536,7 @@ class Builder(Builder):
             5: 2
         }
 
-        order = roFabricToMayaRemap[kSceneItem.ro.order]
+        order = rotOrderRemap[kSceneItem.ro.order]
 
         #  Maya api is one off from Maya's own node enum pyMel uses API
         dccSceneItem.setRotationOrder(order + 1, False)

--- a/Python/kraken/plugins/si_plugin/builder.py
+++ b/Python/kraken/plugins/si_plugin/builder.py
@@ -1411,26 +1411,6 @@ class Builder(Builder):
 
         dccSceneItem = self.getDCCSceneItem(kSceneItem)
 
-        xfo = XSIMath.CreateTransform()
-        sc = XSIMath.CreateVector3(kSceneItem.xfo.sc.x,
-                                   kSceneItem.xfo.sc.y,
-                                   kSceneItem.xfo.sc.z)
-
-        quat = XSIMath.CreateQuaternion(kSceneItem.xfo.ori.w,
-                                        kSceneItem.xfo.ori.v.x,
-                                        kSceneItem.xfo.ori.v.y,
-                                        kSceneItem.xfo.ori.v.z)
-
-        tr = XSIMath.CreateVector3(kSceneItem.xfo.tr.x,
-                                   kSceneItem.xfo.tr.y,
-                                   kSceneItem.xfo.tr.z)
-
-        xfo.SetScaling(sc)
-        xfo.SetRotationFromQuaternion(quat)
-        xfo.SetTranslation(tr)
-
-        dccSceneItem.Kinematics.Global.PutTransform2(None, xfo)
-
         # Rotation order remapping
         # Softimage's enums don't map directly to the Fabric rotation orders
         #
@@ -1454,6 +1434,26 @@ class Builder(Builder):
 
         order = rotOrderRemap[kSceneItem.ro.order]
         dccSceneItem.Kinematics.Local.Parameters('rotorder').Value = order
+
+        xfo = XSIMath.CreateTransform()
+        sc = XSIMath.CreateVector3(kSceneItem.xfo.sc.x,
+                                   kSceneItem.xfo.sc.y,
+                                   kSceneItem.xfo.sc.z)
+
+        quat = XSIMath.CreateQuaternion(kSceneItem.xfo.ori.w,
+                                        kSceneItem.xfo.ori.v.x,
+                                        kSceneItem.xfo.ori.v.y,
+                                        kSceneItem.xfo.ori.v.z)
+
+        tr = XSIMath.CreateVector3(kSceneItem.xfo.tr.x,
+                                   kSceneItem.xfo.tr.y,
+                                   kSceneItem.xfo.tr.z)
+
+        xfo.SetScaling(sc)
+        xfo.SetRotationFromQuaternion(quat)
+        xfo.SetTranslation(tr)
+
+        dccSceneItem.Kinematics.Global.PutTransform2(None, xfo)
 
         return True
 

--- a/Python/kraken/plugins/si_plugin/builder.py
+++ b/Python/kraken/plugins/si_plugin/builder.py
@@ -588,16 +588,25 @@ class Builder(Builder):
 
         if kConstraint.getMaintainOffset() is True:
 
-            # Softimage's rotation orders remapped
-            # It appears Softimage uses the reversed orders
-            # Not the same orders.
+            # Rotation order remapping
+            # Softimage's enums don't map directly to the Fabric rotation orders
+            #
+            # Fabric | Softimage
+            # -------------------
+            # 0 ZYX  | 5 ZYX
+            # 1 XZY  | 1 XZY
+            # 2 YXZ  | 2 YXZ
+            # 3 YZX  | 3 YZX
+            # 4 XYZ  | 0 XYZ
+            # 5 ZXY  | 4 ZXY
+
             rotOrderRemap = {
-                0: 0,
-                1: 3,
-                2: 4,
-                3: 1,
-                4: 5,
-                5: 2
+                0: 5,
+                1: 1,
+                2: 2,
+                3: 3,
+                4: 0,
+                5: 4
             }
 
             order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
@@ -641,33 +650,25 @@ class Builder(Builder):
 
         if kConstraint.getMaintainOffset() is True:
 
-            # Fabric's rotation order enums:
-            # We need to use the negative rotation order
-            # to calculate propery offset values.
+            # Rotation order remapping
+            # Softimage's enums don't map directly to the Fabric rotation orders
             #
-            # 0 XYZ
-            # 1 YZX
-            # 2 ZXY
-            # 3 XZY
-            # 4 ZYX
-            # 5 YXZ
-
-            # Softimage's rotation orders
-            #
-            # 0 XYZ
-            # 1 XZY
-            # 2 YXZ
-            # 3 YZX
-            # 4 ZXY
-            # 5 ZYX
+            # Fabric | Softimage
+            # -------------------
+            # 0 ZYX  | 5 ZYX
+            # 1 XZY  | 1 XZY
+            # 2 YXZ  | 2 YXZ
+            # 3 YZX  | 3 YZX
+            # 4 XYZ  | 0 XYZ
+            # 5 ZXY  | 4 ZXY
 
             rotOrderRemap = {
-                0: 4,
+                0: 5,
                 1: 1,
                 2: 2,
                 3: 3,
-                4: 5,
-                5: 0
+                4: 0,
+                5: 4
             }
 
             order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
@@ -1430,14 +1431,25 @@ class Builder(Builder):
 
         dccSceneItem.Kinematics.Global.PutTransform2(None, xfo)
 
-        # Softimage's rotation orders remapped:
+        # Rotation order remapping
+        # Softimage's enums don't map directly to the Fabric rotation orders
+        #
+        # Fabric | Softimage
+        # -------------------
+        # 0 ZYX  | 5 ZYX
+        # 1 XZY  | 1 XZY
+        # 2 YXZ  | 2 YXZ
+        # 3 YZX  | 3 YZX
+        # 4 XYZ  | 0 XYZ
+        # 5 ZXY  | 4 ZXY
+
         rotOrderRemap = {
-            0: 0,
-            1: 3,
-            2: 4,
-            3: 1,
-            4: 5,
-            5: 2
+            0: 5,
+            1: 1,
+            2: 2,
+            3: 3,
+            4: 0,
+            5: 4
         }
 
         order = rotOrderRemap[kSceneItem.ro.order]

--- a/Python/kraken/plugins/si_plugin/builder.py
+++ b/Python/kraken/plugins/si_plugin/builder.py
@@ -23,8 +23,30 @@ from kraken.helpers.utility_methods import prepareToSave, prepareToLoad
 
 from kraken.plugins.si_plugin.utils import *
 
+
 logger = getLogger('kraken')
 logger.setLevel(logging.INFO)
+
+# Rotation order remapping
+# Softimage's enums don't map directly to the Fabric rotation orders
+#
+# Fabric | Softimage
+# -------------------
+# 0 ZYX  | 5 ZYX
+# 1 XZY  | 1 XZY
+# 2 YXZ  | 2 YXZ
+# 3 YZX  | 3 YZX
+# 4 XYZ  | 0 XYZ
+# 5 ZXY  | 4 ZXY
+
+ROT_ORDER_REMAP = {
+    0: 5,
+    1: 1,
+    2: 2,
+    3: 3,
+    4: 0,
+    5: 4
+}
 
 
 class Builder(Builder):
@@ -588,28 +610,7 @@ class Builder(Builder):
 
         if kConstraint.getMaintainOffset() is True:
 
-            # Rotation order remapping
-            # Softimage's enums don't map directly to the Fabric rotation orders
-            #
-            # Fabric | Softimage
-            # -------------------
-            # 0 ZYX  | 5 ZYX
-            # 1 XZY  | 1 XZY
-            # 2 YXZ  | 2 YXZ
-            # 3 YZX  | 3 YZX
-            # 4 XYZ  | 0 XYZ
-            # 5 ZXY  | 4 ZXY
-
-            rotOrderRemap = {
-                0: 5,
-                1: 1,
-                2: 2,
-                3: 3,
-                4: 0,
-                5: 4
-            }
-
-            order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
+            order = ROT_ORDER_REMAP[kConstraint.getConstrainee().ro.order]
 
             offsetXfo = kConstraint.computeOffset()
             offsetAngles = offsetXfo.ori.toEulerAnglesWithRotOrder(
@@ -650,28 +651,7 @@ class Builder(Builder):
 
         if kConstraint.getMaintainOffset() is True:
 
-            # Rotation order remapping
-            # Softimage's enums don't map directly to the Fabric rotation orders
-            #
-            # Fabric | Softimage
-            # -------------------
-            # 0 ZYX  | 5 ZYX
-            # 1 XZY  | 1 XZY
-            # 2 YXZ  | 2 YXZ
-            # 3 YZX  | 3 YZX
-            # 4 XYZ  | 0 XYZ
-            # 5 ZXY  | 4 ZXY
-
-            rotOrderRemap = {
-                0: 5,
-                1: 1,
-                2: 2,
-                3: 3,
-                4: 0,
-                5: 4
-            }
-
-            order = rotOrderRemap[kConstraint.getConstrainee().ro.order]
+            order = ROT_ORDER_REMAP[kConstraint.getConstrainee().ro.order]
 
             offsetXfo = kConstraint.computeOffset()
             offsetAngles = offsetXfo.ori.toEulerAnglesWithRotOrder(
@@ -1411,28 +1391,7 @@ class Builder(Builder):
 
         dccSceneItem = self.getDCCSceneItem(kSceneItem)
 
-        # Rotation order remapping
-        # Softimage's enums don't map directly to the Fabric rotation orders
-        #
-        # Fabric | Softimage
-        # -------------------
-        # 0 ZYX  | 5 ZYX
-        # 1 XZY  | 1 XZY
-        # 2 YXZ  | 2 YXZ
-        # 3 YZX  | 3 YZX
-        # 4 XYZ  | 0 XYZ
-        # 5 ZXY  | 4 ZXY
-
-        rotOrderRemap = {
-            0: 5,
-            1: 1,
-            2: 2,
-            3: 3,
-            4: 0,
-            5: 4
-        }
-
-        order = rotOrderRemap[kSceneItem.ro.order]
+        order = ROT_ORDER_REMAP[kSceneItem.ro.order]
         dccSceneItem.Kinematics.Local.Parameters('rotorder').Value = order
 
         xfo = XSIMath.CreateTransform()


### PR DESCRIPTION
This pull request updates the rotation order class with the new indices that were changed in the Fabric Core.

I moved the mapping from String to Int to a new constants module so it can be easily imported and used in  other modules within the Kraken package without causing cyclic dependencies of modules.

As for the DCC builders, we need to do a remapping of the rotation orders since we set the DCC object's rotation order via a Rotation Order object. This Rotation Order isn't tied to the `.xfo` of the Object3D. The DCC rotation order indices don't map 1:1 with those in Fabric so this mapping is required in each DCC builder.

The changes here really only reflect the required changes from the core and nothing else.