### PR TITLE
Don't produce warning when output of operator is not connected.  This…

### DIFF
--- a/Python/kraken/plugins/max_plugin/builder.py
+++ b/Python/kraken/plugins/max_plugin/builder.py
@@ -1765,7 +1765,7 @@ class Builder(Builder):
                         else:
                             opType = kOperator.getPresetPath()
 
-                        logger.warning("Operator '" + solverSolveNodeName +
+                        logger.debug("Operator '" + solverSolveNodeName +
                                        "' of type '" + opType +
                                        "' port '" + portName + "' not connected.")
 

--- a/Python/kraken/plugins/maya_plugin/builder.py
+++ b/Python/kraken/plugins/maya_plugin/builder.py
@@ -1175,7 +1175,7 @@ class Builder(Builder):
                         else:
                             opType = kOperator.getPresetPath()
 
-                        logger.warning("Operator '" + solverSolveNodeName +
+                        logger.debug("Operator '" + solverSolveNodeName +
                                        "' of type '" + opType +
                                        "' port '" + portName + "' not connected.")
 


### PR DESCRIPTION
… is a normal valid case that we have all the time and the noise of these warnings is not good.