### PR TITLE
added prepend parameter to     def addSource(self, source, prepend=False):

### DIFF
--- a/Python/kraken/core/objects/scene_item.py
+++ b/Python/kraken/core/objects/scene_item.py
@@ -199,7 +199,7 @@ class SceneItem(object):
 
         self.removeSource(self._parent)
         self._parent = parent
-        self.addSource(parent)
+        self.addSource(parent, prepend=True) #always want parent to be first source, then constraints etc.
 
         return True
 
@@ -229,7 +229,7 @@ class SceneItem(object):
 
         return None
 
-    def addSource(self, source):
+    def addSource(self, source, prepend=False):
         """Adds another source to this object.
 
         Arguments:
@@ -247,7 +247,10 @@ class SceneItem(object):
             if prevSource.getId() == source.getId():
                 return False
 
-        self._sources.append(source)
+        if prepend:
+            self._sources.insert(0, source)
+        else:
+            self._sources.append(source)
 
         if self not in source._depends:
             source._depends.append(self)

--- a/Python/kraken/core/objects/scene_item.py
+++ b/Python/kraken/core/objects/scene_item.py
@@ -234,6 +234,7 @@ class SceneItem(object):
 
         Arguments:
         source (Object): Object that is the source of this one.
+        prepend (bool): Add this source to the beginning of the list instead of the end
 
         Returns:
             int: Index of the source used


### PR DESCRIPTION
We need to use this for parenting when objects already have sources like constraints, etc.  
object3Ds should always be the first in source list.
The system relies on order and currently breaks something I'm doing in the KLbuild, specifically getCurrentSource() depends on this.

## Issue ID
# quick fix

## Description of Changes
A few sentences describing the overall goals of the pull request's commit and the changes involved if deemed necessary.

## Risk Involved
Miniscule
## Getting To Done progress (Mark what you've done)
- [x] Manual Testing
- [ ] Testsuite passes
- [x] Documented