### PR TITLE
FE-8096

### DIFF
--- a/DCCIntegrations/max/krakenInit.ms
+++ b/DCCIntegrations/max/krakenInit.ms
@@ -5,9 +5,12 @@ dotNet.loadAssembly "System"
 env = dotNetClass "system.Environment"
 krakenPath = env.GetEnvironmentVariable "KRAKEN_PATH"
 
-krakeEnvScriptPath = krakenPath + "\DCCIntegrations\max\scripts\krakenEnv.py"
-krakeMenuScriptPath = krakenPath + "\DCCIntegrations\max\scripts\krakenMenu.py"
-
--- Execute Python startup modules
-python.ExecuteFile krakeEnvScriptPath
-python.ExecuteFile krakeMenuScriptPath
+if krakenPath != undefined do
+(
+    krakeEnvScriptPath = krakenPath + "\DCCIntegrations\max\scripts\krakenEnv.py"
+    krakeMenuScriptPath = krakenPath + "\DCCIntegrations\max\scripts\krakenMenu.py"
+    
+    -- Execute Python startup modules
+    python.ExecuteFile krakeEnvScriptPath
+    python.ExecuteFile krakeMenuScriptPath
+)


### PR DESCRIPTION
## Issue ID
FE-8096

## Description of Changes
Fixed Kraken errors when Kraken environment variable isn't set properly in 3dsmax.

## Risk Involved
Low

## Getting To Done progress (Mark what you've done)
- [x] Manual Testing
- [ ] Testsuite passes
- [ ] Documented