### PR TITLE
fix to wrong method call setFromEulerAnglesWithRotOrder 

### DIFF
--- a/Python/kraken/core/maths/quat.py
+++ b/Python/kraken/core/maths/quat.py
@@ -201,7 +201,7 @@ class Quat(MathObject):
 
         """
 
-        return Quat(self._rtval.setFromEuler('Quat', ks.rtVal('Vec3', angles),
+        return Quat(self._rtval.setFromEulerAngles('Quat', ks.rtVal('Vec3', angles),
                     ks.rtVal('RotationOrder', ro)))
 
 


### PR DESCRIPTION
## Issue ID
#

## Description of Changes
setFromEulerAnglesWithRotOrder should call quat.setFromEulerAngles() instead of quat.setFromEuler()

## Risk Involved
miniscule
I get tests failing with or without this change, so running the test suite still is unhelpful.

## Getting To Done progress (Mark what you've done)
- [x ] Manual Testing
- [x ] Testsuite passes
- [x ] Documented